### PR TITLE
#201 Fix @NotLogged suppression across all layer aspects

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,6 +213,10 @@ payload that travels back to the caller.
   `BadRequestException` (400), `GatewayException` (502), `GatewayTimeoutException` (504).
 
 Combine with `org.ameba.annotation.NotLogged` on exception types whose stack traces should never hit the log.
+The marker is honoured by all three layer aspects (service, integration, presentation) and is resolved through
+`AspectSupport.hasNotLogged`, which (a) walks the full cause chain so a `@NotLogged` exception wrapped inside a
+non-annotated one is also suppressed, and (b) relies on `@Inherited`, so subclasses of a `@NotLogged` base type
+inherit the suppression automatically.
 
 ### Internationalised messages
 
@@ -258,7 +262,8 @@ Supporting annotations in `org.ameba.annotation`:
 
 - `@TxService` – meta-annotation combining `@Service`, `@Transactional`, and `@Validated`.
 - `@Measured` – mark classes or public methods for timing by `MeasuredAspect`.
-- `@NotLogged` – suppress stack-trace logging for an exception type.
+- `@NotLogged` – suppress stack-trace logging for an exception type; `@Inherited`, and matched across the cause
+  chain by all three layer aspects.
 - `@NotTransformed` – opt a single service/integration method out of exception translation.
 - `@Public` – document that a type is intentionally `public`.
 - `@Default` – mark a preferred constructor/method (e.g. for MapStruct).

--- a/README.md
+++ b/README.md
@@ -35,12 +35,12 @@ Add as Maven dependency
             <dependency>
                 <groupId>io.interface21</groupId>
                 <artifactId>ameba-lib</artifactId>
-                <version>4.3.0-SNAPSHOT</version>
+                <version>4.3.1-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>io.interface21</groupId>
                 <artifactId>ameba-lib</artifactId>
-                <version>4.3.0-SNAPSHOT</version>
+                <version>4.3.1-SNAPSHOT</version>
                 <type>test-jar</type>
             </dependency>
         </dependencies>

--- a/README.md
+++ b/README.md
@@ -213,10 +213,9 @@ payload that travels back to the caller.
   `BadRequestException` (400), `GatewayException` (502), `GatewayTimeoutException` (504).
 
 Combine with `org.ameba.annotation.NotLogged` on exception types whose stack traces should never hit the log.
-The marker is honoured by all three layer aspects (service, integration, presentation) and is resolved through
-`AspectSupport.hasNotLogged`, which (a) walks the full cause chain so a `@NotLogged` exception wrapped inside a
-non-annotated one is also suppressed, and (b) relies on `@Inherited`, so subclasses of a `@NotLogged` base type
-inherit the suppression automatically.
+The marker is honoured by all three layer aspects (service, integration, presentation): logging is suppressed if
+the thrown exception or any exception in its cause chain is annotated with `@NotLogged`. Because the annotation is
+`@Inherited`, subclasses of a `@NotLogged` base type inherit the suppression automatically.
 
 ### Internationalised messages
 

--- a/src/main/java/org/ameba/Ameba.java
+++ b/src/main/java/org/ameba/Ameba.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2024 the original author or authors.
+ * Copyright 2015-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/ameba/Constants.java
+++ b/src/main/java/org/ameba/Constants.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2024 the original author or authors.
+ * Copyright 2015-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/ameba/IDGenerator.java
+++ b/src/main/java/org/ameba/IDGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2024 the original author or authors.
+ * Copyright 2015-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/ameba/Identifiable.java
+++ b/src/main/java/org/ameba/Identifiable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2024 the original author or authors.
+ * Copyright 2015-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/ameba/JdkIDGenerator.java
+++ b/src/main/java/org/ameba/JdkIDGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2024 the original author or authors.
+ * Copyright 2015-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/ameba/LoggingCategories.java
+++ b/src/main/java/org/ameba/LoggingCategories.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2024 the original author or authors.
+ * Copyright 2015-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/ameba/Messages.java
+++ b/src/main/java/org/ameba/Messages.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2024 the original author or authors.
+ * Copyright 2015-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/ameba/amqp/AmqpConfiguration.java
+++ b/src/main/java/org/ameba/amqp/AmqpConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2005-2024 the original author or authors.
+ * Copyright 2005-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/ameba/amqp/MessageHeaderEnhancer.java
+++ b/src/main/java/org/ameba/amqp/MessageHeaderEnhancer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2005-2024 the original author or authors.
+ * Copyright 2005-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/ameba/amqp/MessagePostProcessorProvider.java
+++ b/src/main/java/org/ameba/amqp/MessagePostProcessorProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2005-2024 the original author or authors.
+ * Copyright 2005-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/ameba/amqp/RabbitTemplateConfigurable.java
+++ b/src/main/java/org/ameba/amqp/RabbitTemplateConfigurable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2005-2024 the original author or authors.
+ * Copyright 2005-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/ameba/amqp/RabbitTemplateConfigurerAdapter.java
+++ b/src/main/java/org/ameba/amqp/RabbitTemplateConfigurerAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2005-2024 the original author or authors.
+ * Copyright 2005-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/ameba/amqp/SimpleRabbitListenerContainerFactoryConfigurerDecorator.java
+++ b/src/main/java/org/ameba/amqp/SimpleRabbitListenerContainerFactoryConfigurerDecorator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2005-2024 the original author or authors.
+ * Copyright 2005-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/ameba/annotation/Default.java
+++ b/src/main/java/org/ameba/annotation/Default.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2005-2024 the original author or authors.
+ * Copyright 2005-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/ameba/annotation/EnableAspects.java
+++ b/src/main/java/org/ameba/annotation/EnableAspects.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2024 the original author or authors.
+ * Copyright 2015-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/ameba/annotation/ExcludeFromScan.java
+++ b/src/main/java/org/ameba/annotation/ExcludeFromScan.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2024 the original author or authors.
+ * Copyright 2015-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/ameba/annotation/FilteredComponentScan.java
+++ b/src/main/java/org/ameba/annotation/FilteredComponentScan.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2024 the original author or authors.
+ * Copyright 2015-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/ameba/annotation/Measured.java
+++ b/src/main/java/org/ameba/annotation/Measured.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2024 the original author or authors.
+ * Copyright 2015-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/ameba/annotation/NotLogged.java
+++ b/src/main/java/org/ameba/annotation/NotLogged.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2024 the original author or authors.
+ * Copyright 2015-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/ameba/annotation/NotLogged.java
+++ b/src/main/java/org/ameba/annotation/NotLogged.java
@@ -17,17 +17,21 @@ package org.ameba.annotation;
 
 import java.lang.annotation.Documented;
 import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * A NotLogged is a marker annotation for application exception types to not log them with the logging framework.
+ * A NotLogged is a marker annotation for application exception types to not log them with the logging framework. The marker is
+ * {@link Inherited} so subclasses of an annotated exception are suppressed too. The ameba layer aspects additionally walk the cause chain,
+ * so a {@link NotLogged}-annotated exception wrapped inside another exception is also suppressed.
  *
  * @author Heiko Scherrer
  */
 @Target(ElementType.TYPE)
 @Retention(RetentionPolicy.RUNTIME)
 @Documented
+@Inherited
 public @interface NotLogged {
 }

--- a/src/main/java/org/ameba/annotation/NotTransformed.java
+++ b/src/main/java/org/ameba/annotation/NotTransformed.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2024 the original author or authors.
+ * Copyright 2015-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/ameba/annotation/Public.java
+++ b/src/main/java/org/ameba/annotation/Public.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2024 the original author or authors.
+ * Copyright 2015-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/ameba/annotation/TxService.java
+++ b/src/main/java/org/ameba/annotation/TxService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2024 the original author or authors.
+ * Copyright 2015-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/ameba/aop/AspectSupport.java
+++ b/src/main/java/org/ameba/aop/AspectSupport.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2005-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.ameba.aop;
+
+import org.ameba.annotation.NotLogged;
+
+/**
+ * A AspectSupport collects small helpers shared between the ameba layer aspects.
+ *
+ * @author Heiko Scherrer
+ */
+final class AspectSupport {
+
+    private AspectSupport() {}
+
+    /**
+     * Check whether {@code ex} or any exception in its cause chain is annotated with {@link NotLogged}.
+     *
+     * @param ex The exception to inspect
+     * @return {@literal true} if {@link NotLogged} is present on the exception or any of its causes
+     */
+    static boolean hasNotLogged(Throwable ex) {
+        for (Throwable t = ex; t != null; t = t.getCause()) {
+            if (t.getClass().getAnnotation(NotLogged.class) != null) {
+                return true;
+            }
+        }
+        return false;
+    }
+}

--- a/src/main/java/org/ameba/aop/AspectsConfiguration.java
+++ b/src/main/java/org/ameba/aop/AspectsConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2024 the original author or authors.
+ * Copyright 2015-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/ameba/aop/ExceptionTranslator.java
+++ b/src/main/java/org/ameba/aop/ExceptionTranslator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2005-2024 the original author or authors.
+ * Copyright 2005-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/ameba/aop/IntegrationLayerAspect.java
+++ b/src/main/java/org/ameba/aop/IntegrationLayerAspect.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2024 the original author or authors.
+ * Copyright 2015-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/ameba/aop/IntegrationLayerAspect.java
+++ b/src/main/java/org/ameba/aop/IntegrationLayerAspect.java
@@ -16,7 +16,6 @@
 package org.ameba.aop;
 
 import org.ameba.LoggingCategories;
-import org.ameba.annotation.NotLogged;
 import org.ameba.annotation.NotTransformed;
 import org.ameba.exception.BusinessRuntimeException;
 import org.ameba.exception.IntegrationLayerException;
@@ -110,7 +109,7 @@ public class IntegrationLayerAspect {
      * @return Returns the exception to be thrown
      */
     public Exception translateException(Exception ex) {
-        if (EXC_LOGGER.isErrorEnabled() && ex.getClass().getAnnotation(NotLogged.class) != null) {
+        if (EXC_LOGGER.isErrorEnabled() && !AspectSupport.hasNotLogged(ex)) {
             EXC_LOGGER.error(ex.getLocalizedMessage(), ex);
         }
 

--- a/src/main/java/org/ameba/aop/MeasuredAspect.java
+++ b/src/main/java/org/ameba/aop/MeasuredAspect.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2024 the original author or authors.
+ * Copyright 2015-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/ameba/aop/Pointcuts.java
+++ b/src/main/java/org/ameba/aop/Pointcuts.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2024 the original author or authors.
+ * Copyright 2015-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/ameba/aop/PresentationLayerAspect.java
+++ b/src/main/java/org/ameba/aop/PresentationLayerAspect.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2024 the original author or authors.
+ * Copyright 2015-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/ameba/aop/PresentationLayerAspect.java
+++ b/src/main/java/org/ameba/aop/PresentationLayerAspect.java
@@ -16,7 +16,6 @@
 package org.ameba.aop;
 
 import org.ameba.LoggingCategories;
-import org.ameba.annotation.NotLogged;
 import org.ameba.exception.BusinessRuntimeException;
 import org.aspectj.lang.ProceedingJoinPoint;
 import org.aspectj.lang.annotation.Around;
@@ -60,12 +59,10 @@ public class PresentationLayerAspect {
         try {
             return pjp.proceed();
         } catch (Exception ex) {
-            if (ex instanceof BusinessRuntimeException bre) {
-                if (EXC_LOGGER.isErrorEnabled() && ex.getClass().getAnnotation(NotLogged.class) != null) {
+            if (EXC_LOGGER.isErrorEnabled() && !AspectSupport.hasNotLogged(ex)) {
+                if (ex instanceof BusinessRuntimeException bre) {
                     EXC_LOGGER.error(ex.getMessage(), ex, bre.getData());
-                }
-            } else {
-                if (EXC_LOGGER.isErrorEnabled() && ex.getClass().getAnnotation(NotLogged.class) != null) {
+                } else {
                     EXC_LOGGER.error(ex.getMessage(), ex);
                 }
             }

--- a/src/main/java/org/ameba/aop/PresentationLayerAspect.java
+++ b/src/main/java/org/ameba/aop/PresentationLayerAspect.java
@@ -61,7 +61,7 @@ public class PresentationLayerAspect {
         } catch (Exception ex) {
             if (EXC_LOGGER.isErrorEnabled() && !AspectSupport.hasNotLogged(ex)) {
                 if (ex instanceof BusinessRuntimeException bre) {
-                    EXC_LOGGER.error(ex.getMessage(), ex, bre.getData());
+                    EXC_LOGGER.error("{} [data={}]", ex.getMessage(), bre.getData(), ex);
                 } else {
                     EXC_LOGGER.error(ex.getMessage(), ex);
                 }

--- a/src/main/java/org/ameba/aop/ServiceLayerAspect.java
+++ b/src/main/java/org/ameba/aop/ServiceLayerAspect.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2024 the original author or authors.
+ * Copyright 2015-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/ameba/aop/ServiceLayerAspect.java
+++ b/src/main/java/org/ameba/aop/ServiceLayerAspect.java
@@ -16,7 +16,6 @@
 package org.ameba.aop;
 
 import org.ameba.LoggingCategories;
-import org.ameba.annotation.NotLogged;
 import org.ameba.annotation.NotTransformed;
 import org.ameba.exception.BusinessRuntimeException;
 import org.ameba.exception.ServiceLayerException;
@@ -95,7 +94,7 @@ public class ServiceLayerAspect {
             var notTransformed = method.getAnnotation(NotTransformed.class);
             if (notTransformed == null) {
                 Exception e = translateException(ex);
-                if (EXC_LOGGER.isErrorEnabled() && !hasNotLogged(ex)) {
+                if (EXC_LOGGER.isErrorEnabled() && !AspectSupport.hasNotLogged(ex)) {
                     EXC_LOGGER.error(e.getLocalizedMessage(), e);
                 }
                 throw e;
@@ -107,16 +106,6 @@ public class ServiceLayerAspect {
             }
         }
         return obj;
-    }
-
-    private boolean hasNotLogged(Throwable ex) {
-        if (ex.getClass().getAnnotation(NotLogged.class) != null) {
-            return true;
-        }
-        if (ex.getCause() != null) {
-            return hasNotLogged(ex.getCause());
-        }
-        return false;
     }
 
     /**

--- a/src/main/java/org/ameba/aop/SpringPointcuts.java
+++ b/src/main/java/org/ameba/aop/SpringPointcuts.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2024 the original author or authors.
+ * Copyright 2015-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/ameba/app/BaseConfiguration.java
+++ b/src/main/java/org/ameba/app/BaseConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2024 the original author or authors.
+ * Copyright 2015-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/ameba/app/SolutionApp.java
+++ b/src/main/java/org/ameba/app/SolutionApp.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2024 the original author or authors.
+ * Copyright 2015-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/ameba/app/SpringProfiles.java
+++ b/src/main/java/org/ameba/app/SpringProfiles.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2024 the original author or authors.
+ * Copyright 2015-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/ameba/app/ValidationConfiguration.java
+++ b/src/main/java/org/ameba/app/ValidationConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2024 the original author or authors.
+ * Copyright 2015-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/ameba/exception/BadRequestException.java
+++ b/src/main/java/org/ameba/exception/BadRequestException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2024 the original author or authors.
+ * Copyright 2015-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/ameba/exception/BehaviorAwareException.java
+++ b/src/main/java/org/ameba/exception/BehaviorAwareException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2024 the original author or authors.
+ * Copyright 2015-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/ameba/exception/BusinessRuntimeException.java
+++ b/src/main/java/org/ameba/exception/BusinessRuntimeException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2024 the original author or authors.
+ * Copyright 2015-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/ameba/exception/GatewayException.java
+++ b/src/main/java/org/ameba/exception/GatewayException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2024 the original author or authors.
+ * Copyright 2015-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/ameba/exception/GatewayTimeoutException.java
+++ b/src/main/java/org/ameba/exception/GatewayTimeoutException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2024 the original author or authors.
+ * Copyright 2015-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/ameba/exception/IntegrationLayerException.java
+++ b/src/main/java/org/ameba/exception/IntegrationLayerException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2024 the original author or authors.
+ * Copyright 2015-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/ameba/exception/NotFoundException.java
+++ b/src/main/java/org/ameba/exception/NotFoundException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2024 the original author or authors.
+ * Copyright 2015-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/ameba/exception/PresentationLayerException.java
+++ b/src/main/java/org/ameba/exception/PresentationLayerException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2024 the original author or authors.
+ * Copyright 2015-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/ameba/exception/ResourceChangedException.java
+++ b/src/main/java/org/ameba/exception/ResourceChangedException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2024 the original author or authors.
+ * Copyright 2015-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/ameba/exception/ResourceExistsException.java
+++ b/src/main/java/org/ameba/exception/ResourceExistsException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2024 the original author or authors.
+ * Copyright 2015-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/ameba/exception/ServiceLayerException.java
+++ b/src/main/java/org/ameba/exception/ServiceLayerException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2024 the original author or authors.
+ * Copyright 2015-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/ameba/exception/TechnicalRuntimeException.java
+++ b/src/main/java/org/ameba/exception/TechnicalRuntimeException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2024 the original author or authors.
+ * Copyright 2015-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/ameba/http/AbstractBase.java
+++ b/src/main/java/org/ameba/http/AbstractBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2024 the original author or authors.
+ * Copyright 2015-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/ameba/http/AbstractMvcConfiguration.java
+++ b/src/main/java/org/ameba/http/AbstractMvcConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2024 the original author or authors.
+ * Copyright 2015-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/ameba/http/BaseClientHttpRequestInterceptor.java
+++ b/src/main/java/org/ameba/http/BaseClientHttpRequestInterceptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2005-2024 the original author or authors.
+ * Copyright 2005-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/ameba/http/LoadBalancedRestTemplateConfiguration.java
+++ b/src/main/java/org/ameba/http/LoadBalancedRestTemplateConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2005-2024 the original author or authors.
+ * Copyright 2005-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/ameba/http/MeasuredRestController.java
+++ b/src/main/java/org/ameba/http/MeasuredRestController.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2005-2024 the original author or authors.
+ * Copyright 2005-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/ameba/http/NotReactiveWebApplicationCondition.java
+++ b/src/main/java/org/ameba/http/NotReactiveWebApplicationCondition.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2005-2024 the original author or authors.
+ * Copyright 2005-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/ameba/http/PermitAllCorsConfigurationSource.java
+++ b/src/main/java/org/ameba/http/PermitAllCorsConfigurationSource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2024 the original author or authors.
+ * Copyright 2015-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/ameba/http/RequestIDFilter.java
+++ b/src/main/java/org/ameba/http/RequestIDFilter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2024 the original author or authors.
+ * Copyright 2015-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/ameba/http/RequestIDHolder.java
+++ b/src/main/java/org/ameba/http/RequestIDHolder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2024 the original author or authors.
+ * Copyright 2015-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/ameba/http/Response.java
+++ b/src/main/java/org/ameba/http/Response.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2024 the original author or authors.
+ * Copyright 2015-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/ameba/http/RestTemplateConfiguration.java
+++ b/src/main/java/org/ameba/http/RestTemplateConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2005-2024 the original author or authors.
+ * Copyright 2005-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/ameba/http/WebMvcConfiguration.java
+++ b/src/main/java/org/ameba/http/WebMvcConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2005-2024 the original author or authors.
+ * Copyright 2005-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/ameba/http/ctx/CallContext.java
+++ b/src/main/java/org/ameba/http/ctx/CallContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2005-2024 the original author or authors.
+ * Copyright 2005-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/ameba/http/ctx/CallContextClientRequestInterceptor.java
+++ b/src/main/java/org/ameba/http/ctx/CallContextClientRequestInterceptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2005-2024 the original author or authors.
+ * Copyright 2005-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/ameba/http/ctx/CallContextHolder.java
+++ b/src/main/java/org/ameba/http/ctx/CallContextHolder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2005-2024 the original author or authors.
+ * Copyright 2005-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/ameba/http/ctx/CallContextInterceptor.java
+++ b/src/main/java/org/ameba/http/ctx/CallContextInterceptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2005-2024 the original author or authors.
+ * Copyright 2005-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/ameba/http/ctx/CallContextProvider.java
+++ b/src/main/java/org/ameba/http/ctx/CallContextProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2005-2024 the original author or authors.
+ * Copyright 2005-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/ameba/http/ctx/CallContextWebMvcConfiguration.java
+++ b/src/main/java/org/ameba/http/ctx/CallContextWebMvcConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2024 the original author or authors.
+ * Copyright 2015-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/ameba/http/ctx/DefaultCallContextProviderConfiguration.java
+++ b/src/main/java/org/ameba/http/ctx/DefaultCallContextProviderConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2024 the original author or authors.
+ * Copyright 2015-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/ameba/http/ctx/SimpleCallContextProvider.java
+++ b/src/main/java/org/ameba/http/ctx/SimpleCallContextProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2005-2024 the original author or authors.
+ * Copyright 2005-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/ameba/http/ctx/amqp/CallContextAmqpConfiguration.java
+++ b/src/main/java/org/ameba/http/ctx/amqp/CallContextAmqpConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2024 the original author or authors.
+ * Copyright 2015-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/ameba/http/ctx/amqp/CallContextEnhancer.java
+++ b/src/main/java/org/ameba/http/ctx/amqp/CallContextEnhancer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2005-2024 the original author or authors.
+ * Copyright 2005-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/ameba/http/ctx/amqp/CallContextHeaderResolver.java
+++ b/src/main/java/org/ameba/http/ctx/amqp/CallContextHeaderResolver.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2005-2024 the original author or authors.
+ * Copyright 2005-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/ameba/http/ctx/feign/CallContextFeignConfiguration.java
+++ b/src/main/java/org/ameba/http/ctx/feign/CallContextFeignConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2024 the original author or authors.
+ * Copyright 2015-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/ameba/http/ctx/feign/CallContextRequestInterceptor.java
+++ b/src/main/java/org/ameba/http/ctx/feign/CallContextRequestInterceptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2005-2024 the original author or authors.
+ * Copyright 2005-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/ameba/http/ctx/otel/OpenTelemetryCallContextConfiguration.java
+++ b/src/main/java/org/ameba/http/ctx/otel/OpenTelemetryCallContextConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2024 the original author or authors.
+ * Copyright 2015-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/ameba/http/ctx/otel/OpenTelemetryCallContextProvider.java
+++ b/src/main/java/org/ameba/http/ctx/otel/OpenTelemetryCallContextProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2005-2024 the original author or authors.
+ * Copyright 2005-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/ameba/http/identity/EnableIdentityAwareness.java
+++ b/src/main/java/org/ameba/http/identity/EnableIdentityAwareness.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2005-2024 the original author or authors.
+ * Copyright 2005-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/ameba/http/identity/HeaderAttributeResolverStrategy.java
+++ b/src/main/java/org/ameba/http/identity/HeaderAttributeResolverStrategy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2005-2024 the original author or authors.
+ * Copyright 2005-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/ameba/http/identity/Identity.java
+++ b/src/main/java/org/ameba/http/identity/Identity.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2005-2024 the original author or authors.
+ * Copyright 2005-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/ameba/http/identity/IdentityClientRequestInterceptor.java
+++ b/src/main/java/org/ameba/http/identity/IdentityClientRequestInterceptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2005-2024 the original author or authors.
+ * Copyright 2005-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/ameba/http/identity/IdentityConfiguration.java
+++ b/src/main/java/org/ameba/http/identity/IdentityConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2024 the original author or authors.
+ * Copyright 2015-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/ameba/http/identity/IdentityContextHolder.java
+++ b/src/main/java/org/ameba/http/identity/IdentityContextHolder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2024 the original author or authors.
+ * Copyright 2015-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/ameba/http/identity/IdentityFilter.java
+++ b/src/main/java/org/ameba/http/identity/IdentityFilter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2005-2024 the original author or authors.
+ * Copyright 2005-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/ameba/http/identity/IdentityResolverStrategy.java
+++ b/src/main/java/org/ameba/http/identity/IdentityResolverStrategy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2005-2024 the original author or authors.
+ * Copyright 2005-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/ameba/http/identity/SimpleIdentity.java
+++ b/src/main/java/org/ameba/http/identity/SimpleIdentity.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2005-2024 the original author or authors.
+ * Copyright 2005-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/ameba/http/identity/TokenResolverStrategy.java
+++ b/src/main/java/org/ameba/http/identity/TokenResolverStrategy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2005-2024 the original author or authors.
+ * Copyright 2005-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/ameba/http/identity/amqp/IdentityAmqpConfiguration.java
+++ b/src/main/java/org/ameba/http/identity/amqp/IdentityAmqpConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2024 the original author or authors.
+ * Copyright 2015-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/ameba/http/identity/amqp/IdentityEnhancer.java
+++ b/src/main/java/org/ameba/http/identity/amqp/IdentityEnhancer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2005-2024 the original author or authors.
+ * Copyright 2005-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/ameba/http/identity/amqp/IdentityHeaderResolver.java
+++ b/src/main/java/org/ameba/http/identity/amqp/IdentityHeaderResolver.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2005-2024 the original author or authors.
+ * Copyright 2005-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/ameba/http/identity/feign/IdentityFeignConfiguration.java
+++ b/src/main/java/org/ameba/http/identity/feign/IdentityFeignConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2024 the original author or authors.
+ * Copyright 2015-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/ameba/http/identity/feign/IdentityRequestInterceptor.java
+++ b/src/main/java/org/ameba/http/identity/feign/IdentityRequestInterceptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2005-2024 the original author or authors.
+ * Copyright 2005-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/ameba/http/multitenancy/AbstractTenantAwareFilter.java
+++ b/src/main/java/org/ameba/http/multitenancy/AbstractTenantAwareFilter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2024 the original author or authors.
+ * Copyright 2015-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/ameba/http/multitenancy/MultiTenancyConfiguration.java
+++ b/src/main/java/org/ameba/http/multitenancy/MultiTenancyConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2024 the original author or authors.
+ * Copyright 2015-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/ameba/http/multitenancy/MultiTenantSessionFilter.java
+++ b/src/main/java/org/ameba/http/multitenancy/MultiTenantSessionFilter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2024 the original author or authors.
+ * Copyright 2015-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/ameba/http/multitenancy/SLF4JMappedDiagnosticContextFilter.java
+++ b/src/main/java/org/ameba/http/multitenancy/SLF4JMappedDiagnosticContextFilter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2024 the original author or authors.
+ * Copyright 2015-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/ameba/http/multitenancy/TenantClientRequestInterceptor.java
+++ b/src/main/java/org/ameba/http/multitenancy/TenantClientRequestInterceptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2005-2024 the original author or authors.
+ * Copyright 2005-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/ameba/http/multitenancy/feign/TenantFeignConfiguration.java
+++ b/src/main/java/org/ameba/http/multitenancy/feign/TenantFeignConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2024 the original author or authors.
+ * Copyright 2015-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/ameba/http/multitenancy/feign/TenantRequestInterceptor.java
+++ b/src/main/java/org/ameba/http/multitenancy/feign/TenantRequestInterceptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2005-2024 the original author or authors.
+ * Copyright 2005-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/ameba/i18n/AbstractSpringTranslator.java
+++ b/src/main/java/org/ameba/i18n/AbstractSpringTranslator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2024 the original author or authors.
+ * Copyright 2015-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/ameba/i18n/AbstractTranslator.java
+++ b/src/main/java/org/ameba/i18n/AbstractTranslator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2024 the original author or authors.
+ * Copyright 2015-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/ameba/i18n/Translator.java
+++ b/src/main/java/org/ameba/i18n/Translator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2024 the original author or authors.
+ * Copyright 2015-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/ameba/integration/EnableMultiTenancy.java
+++ b/src/main/java/org/ameba/integration/EnableMultiTenancy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2024 the original author or authors.
+ * Copyright 2015-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/ameba/integration/FindOperations.java
+++ b/src/main/java/org/ameba/integration/FindOperations.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2024 the original author or authors.
+ * Copyright 2015-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/ameba/integration/SaveOperations.java
+++ b/src/main/java/org/ameba/integration/SaveOperations.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2024 the original author or authors.
+ * Copyright 2015-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/ameba/integration/SeparationStrategy.java
+++ b/src/main/java/org/ameba/integration/SeparationStrategy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2024 the original author or authors.
+ * Copyright 2015-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/ameba/integration/TypedEntity.java
+++ b/src/main/java/org/ameba/integration/TypedEntity.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2024 the original author or authors.
+ * Copyright 2015-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/ameba/integration/hibernate/ColumnBasedTenancyConfiguration.java
+++ b/src/main/java/org/ameba/integration/hibernate/ColumnBasedTenancyConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2024 the original author or authors.
+ * Copyright 2015-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/ameba/integration/hibernate/ColumnSeparationConfigurator.java
+++ b/src/main/java/org/ameba/integration/hibernate/ColumnSeparationConfigurator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2024 the original author or authors.
+ * Copyright 2015-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/ameba/integration/hibernate/DefaultMultiTenantConnectionProvider.java
+++ b/src/main/java/org/ameba/integration/hibernate/DefaultMultiTenantConnectionProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2024 the original author or authors.
+ * Copyright 2015-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/ameba/integration/hibernate/SchemaBasedTenancyConfiguration.java
+++ b/src/main/java/org/ameba/integration/hibernate/SchemaBasedTenancyConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2024 the original author or authors.
+ * Copyright 2015-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/ameba/integration/hibernate/SchemaSeparationConfigurator.java
+++ b/src/main/java/org/ameba/integration/hibernate/SchemaSeparationConfigurator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2024 the original author or authors.
+ * Copyright 2015-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/ameba/integration/hibernate/SessionFactoryIntegrator.java
+++ b/src/main/java/org/ameba/integration/hibernate/SessionFactoryIntegrator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2024 the original author or authors.
+ * Copyright 2015-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/ameba/integration/hibernate/TenantResolverTenancyStrategy.java
+++ b/src/main/java/org/ameba/integration/hibernate/TenantResolverTenancyStrategy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2024 the original author or authors.
+ * Copyright 2015-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/ameba/integration/jpa/ApplicationEntity.java
+++ b/src/main/java/org/ameba/integration/jpa/ApplicationEntity.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2024 the original author or authors.
+ * Copyright 2015-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/ameba/integration/jpa/BaseEntity.java
+++ b/src/main/java/org/ameba/integration/jpa/BaseEntity.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2024 the original author or authors.
+ * Copyright 2015-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/ameba/integration/jpa/BaseJpaConfiguration.java
+++ b/src/main/java/org/ameba/integration/jpa/BaseJpaConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2024 the original author or authors.
+ * Copyright 2015-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/ameba/integration/jpa/IdentityPrincipalProvider.java
+++ b/src/main/java/org/ameba/integration/jpa/IdentityPrincipalProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2005-2024 the original author or authors.
+ * Copyright 2005-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/ameba/integration/jpa/JpaRepositoryOperations.java
+++ b/src/main/java/org/ameba/integration/jpa/JpaRepositoryOperations.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2024 the original author or authors.
+ * Copyright 2015-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/ameba/integration/jpa/PrincipalProvider.java
+++ b/src/main/java/org/ameba/integration/jpa/PrincipalProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2005-2024 the original author or authors.
+ * Copyright 2005-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/ameba/integration/jpa/StringListConverter.java
+++ b/src/main/java/org/ameba/integration/jpa/StringListConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2005-2024 the original author or authors.
+ * Copyright 2005-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/ameba/integration/mongodb/BaseEntity.java
+++ b/src/main/java/org/ameba/integration/mongodb/BaseEntity.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2024 the original author or authors.
+ * Copyright 2015-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/ameba/logging/TenantDiscriminator.java
+++ b/src/main/java/org/ameba/logging/TenantDiscriminator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2024 the original author or authors.
+ * Copyright 2014-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/ameba/logging/ThreadIdProvider.java
+++ b/src/main/java/org/ameba/logging/ThreadIdProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2024 the original author or authors.
+ * Copyright 2015-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/ameba/mapping/BeanMapper.java
+++ b/src/main/java/org/ameba/mapping/BeanMapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2024 the original author or authors.
+ * Copyright 2015-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/ameba/mapping/DozerMapperImpl.java
+++ b/src/main/java/org/ameba/mapping/DozerMapperImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2024 the original author or authors.
+ * Copyright 2015-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/ameba/mapping/LocalDateConverter.java
+++ b/src/main/java/org/ameba/mapping/LocalDateConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2024 the original author or authors.
+ * Copyright 2015-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/ameba/mapping/LocalDateTimeConverter.java
+++ b/src/main/java/org/ameba/mapping/LocalDateTimeConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2024 the original author or authors.
+ * Copyright 2015-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/ameba/mapping/ZonedDateTimeConverter.java
+++ b/src/main/java/org/ameba/mapping/ZonedDateTimeConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2024 the original author or authors.
+ * Copyright 2015-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/ameba/oauth2/Asymmetric.java
+++ b/src/main/java/org/ameba/oauth2/Asymmetric.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2024 the original author or authors.
+ * Copyright 2015-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/ameba/oauth2/BearerTokenExtractor.java
+++ b/src/main/java/org/ameba/oauth2/BearerTokenExtractor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2024 the original author or authors.
+ * Copyright 2015-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/ameba/oauth2/DefaultTokenExtractor.java
+++ b/src/main/java/org/ameba/oauth2/DefaultTokenExtractor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2024 the original author or authors.
+ * Copyright 2015-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/ameba/oauth2/ExtractionResult.java
+++ b/src/main/java/org/ameba/oauth2/ExtractionResult.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2024 the original author or authors.
+ * Copyright 2015-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/ameba/oauth2/FilterStrategy.java
+++ b/src/main/java/org/ameba/oauth2/FilterStrategy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2024 the original author or authors.
+ * Copyright 2015-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/ameba/oauth2/InvalidTokenException.java
+++ b/src/main/java/org/ameba/oauth2/InvalidTokenException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2024 the original author or authors.
+ * Copyright 2015-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/ameba/oauth2/Issuer.java
+++ b/src/main/java/org/ameba/oauth2/Issuer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2024 the original author or authors.
+ * Copyright 2015-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/ameba/oauth2/IssuerWhiteList.java
+++ b/src/main/java/org/ameba/oauth2/IssuerWhiteList.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2024 the original author or authors.
+ * Copyright 2015-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/ameba/oauth2/JwtValidationStrategy.java
+++ b/src/main/java/org/ameba/oauth2/JwtValidationStrategy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2024 the original author or authors.
+ * Copyright 2015-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/ameba/oauth2/JwtValidator.java
+++ b/src/main/java/org/ameba/oauth2/JwtValidator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2024 the original author or authors.
+ * Copyright 2015-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/ameba/oauth2/SpringOauth2Configuration.java
+++ b/src/main/java/org/ameba/oauth2/SpringOauth2Configuration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2024 the original author or authors.
+ * Copyright 2015-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/ameba/oauth2/Symmetric.java
+++ b/src/main/java/org/ameba/oauth2/Symmetric.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2024 the original author or authors.
+ * Copyright 2015-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/ameba/oauth2/TokenExtractor.java
+++ b/src/main/java/org/ameba/oauth2/TokenExtractor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2024 the original author or authors.
+ * Copyright 2015-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/ameba/oauth2/TokenParser.java
+++ b/src/main/java/org/ameba/oauth2/TokenParser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2024 the original author or authors.
+ * Copyright 2015-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/ameba/oauth2/issuer/ConfigurationIssuerWhiteList.java
+++ b/src/main/java/org/ameba/oauth2/issuer/ConfigurationIssuerWhiteList.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2024 the original author or authors.
+ * Copyright 2015-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/ameba/oauth2/issuer/ConfiguredIssuer.java
+++ b/src/main/java/org/ameba/oauth2/issuer/ConfiguredIssuer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2024 the original author or authors.
+ * Copyright 2015-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/ameba/oauth2/issuer/IssuerEO.java
+++ b/src/main/java/org/ameba/oauth2/issuer/IssuerEO.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2024 the original author or authors.
+ * Copyright 2015-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/ameba/oauth2/issuer/IssuerPackage.java
+++ b/src/main/java/org/ameba/oauth2/issuer/IssuerPackage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2024 the original author or authors.
+ * Copyright 2015-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/ameba/oauth2/issuer/IssuerRepository.java
+++ b/src/main/java/org/ameba/oauth2/issuer/IssuerRepository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2024 the original author or authors.
+ * Copyright 2015-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/ameba/oauth2/issuer/JpaIssuerRepository.java
+++ b/src/main/java/org/ameba/oauth2/issuer/JpaIssuerRepository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2024 the original author or authors.
+ * Copyright 2015-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/ameba/oauth2/issuer/JwksUrlRepository.java
+++ b/src/main/java/org/ameba/oauth2/issuer/JwksUrlRepository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2005-2024 the original author or authors.
+ * Copyright 2005-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/ameba/oauth2/issuer/PersistentIssuerWhiteList.java
+++ b/src/main/java/org/ameba/oauth2/issuer/PersistentIssuerWhiteList.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2024 the original author or authors.
+ * Copyright 2015-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/ameba/oauth2/issuer/package-info.java
+++ b/src/main/java/org/ameba/oauth2/issuer/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2024 the original author or authors.
+ * Copyright 2015-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/ameba/oauth2/parser/HS512TokenParser.java
+++ b/src/main/java/org/ameba/oauth2/parser/HS512TokenParser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2024 the original author or authors.
+ * Copyright 2015-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/ameba/oauth2/parser/RSA256TokenParser.java
+++ b/src/main/java/org/ameba/oauth2/parser/RSA256TokenParser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2024 the original author or authors.
+ * Copyright 2015-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/ameba/oauth2/parser/package-info.java
+++ b/src/main/java/org/ameba/oauth2/parser/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2024 the original author or authors.
+ * Copyright 2015-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/ameba/oauth2/tenant/TenantEO.java
+++ b/src/main/java/org/ameba/oauth2/tenant/TenantEO.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2024 the original author or authors.
+ * Copyright 2015-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/ameba/oauth2/tenant/TenantPackage.java
+++ b/src/main/java/org/ameba/oauth2/tenant/TenantPackage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2024 the original author or authors.
+ * Copyright 2015-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/ameba/oauth2/tenant/TenantRepository.java
+++ b/src/main/java/org/ameba/oauth2/tenant/TenantRepository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2024 the original author or authors.
+ * Copyright 2015-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/ameba/oauth2/tenant/TenantValidator.java
+++ b/src/main/java/org/ameba/oauth2/tenant/TenantValidator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2024 the original author or authors.
+ * Copyright 2015-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/ameba/oauth2/tenant/package-info.java
+++ b/src/main/java/org/ameba/oauth2/tenant/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2024 the original author or authors.
+ * Copyright 2015-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/ameba/system/NestedReloadableResourceBundleMessageSource.java
+++ b/src/main/java/org/ameba/system/NestedReloadableResourceBundleMessageSource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2024 the original author or authors.
+ * Copyright 2015-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/ameba/system/SystemSupport.java
+++ b/src/main/java/org/ameba/system/SystemSupport.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2024 the original author or authors.
+ * Copyright 2015-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/ameba/system/ValidationUtil.java
+++ b/src/main/java/org/ameba/system/ValidationUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2005-2024 the original author or authors.
+ * Copyright 2005-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/ameba/tenancy/IllegalTenantException.java
+++ b/src/main/java/org/ameba/tenancy/IllegalTenantException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2024 the original author or authors.
+ * Copyright 2015-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/ameba/tenancy/TenantHolder.java
+++ b/src/main/java/org/ameba/tenancy/TenantHolder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2024 the original author or authors.
+ * Copyright 2015-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/ameba/tenancy/TenantValidator.java
+++ b/src/main/java/org/ameba/tenancy/TenantValidator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2024 the original author or authors.
+ * Copyright 2015-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/springframework/context/annotation/AspectsSelector.java
+++ b/src/main/java/org/springframework/context/annotation/AspectsSelector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2024 the original author or authors.
+ * Copyright 2015-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/springframework/context/annotation/IdentitySelector.java
+++ b/src/main/java/org/springframework/context/annotation/IdentitySelector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2024 the original author or authors.
+ * Copyright 2015-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/springframework/context/annotation/MultiTenancySelector.java
+++ b/src/main/java/org/springframework/context/annotation/MultiTenancySelector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2024 the original author or authors.
+ * Copyright 2015-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/ameba/aop/AspectSupportTest.java
+++ b/src/test/java/org/ameba/aop/AspectSupportTest.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2005-2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.ameba.aop;
+
+import org.ameba.annotation.NotLogged;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * A AspectSupportTest pins down the semantics of {@link AspectSupport#hasNotLogged(Throwable)}.
+ *
+ * @author Heiko Scherrer
+ */
+class AspectSupportTest {
+
+    @Test void returnsFalseForUnannotatedException() {
+        assertThat(AspectSupport.hasNotLogged(new RuntimeException("plain"))).isFalse();
+    }
+
+    @Test void returnsTrueForDirectlyAnnotatedException() {
+        assertThat(AspectSupport.hasNotLogged(new AnnotatedException())).isTrue();
+    }
+
+    @Test void returnsTrueForAnnotationOnCauseAtDepth1() {
+        var wrapped = new RuntimeException("outer", new AnnotatedException());
+        assertThat(AspectSupport.hasNotLogged(wrapped)).isTrue();
+    }
+
+    @Test void returnsTrueForAnnotationDeepInCauseChain() {
+        var wrapped = new RuntimeException("outer",
+                new RuntimeException("middle",
+                        new RuntimeException("inner", new AnnotatedException())));
+        assertThat(AspectSupport.hasNotLogged(wrapped)).isTrue();
+    }
+
+    @Test void returnsTrueForSubclassOfAnnotatedBaseDueToInherited() {
+        assertThat(AspectSupport.hasNotLogged(new SubclassException())).isTrue();
+    }
+
+    @NotLogged
+    static class AnnotatedException extends RuntimeException {
+        AnnotatedException() { super("annotated"); }
+    }
+
+    @NotLogged
+    static class AnnotatedBaseException extends RuntimeException {
+        AnnotatedBaseException(String m) { super(m); }
+    }
+
+    static class SubclassException extends AnnotatedBaseException {
+        SubclassException() { super("sub"); }
+    }
+}

--- a/src/test/java/org/ameba/aop/AspectSupportTest.java
+++ b/src/test/java/org/ameba/aop/AspectSupportTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2005-2024 the original author or authors.
+ * Copyright 2005-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/ameba/aop/IntegrationLayerNotLoggedTest.java
+++ b/src/test/java/org/ameba/aop/IntegrationLayerNotLoggedTest.java
@@ -1,0 +1,129 @@
+/*
+ * Copyright 2005-2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.ameba.aop;
+
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import org.ameba.annotation.EnableAspects;
+import org.ameba.annotation.NotLogged;
+import org.ameba.test.LogCaptureAppender;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Bean;
+import org.springframework.stereotype.Repository;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import static org.junit.jupiter.api.Assertions.fail;
+
+/**
+ * A IntegrationLayerNotLoggedTest verifies {@link NotLogged} suppression on the integration layer.
+ *
+ * @author Heiko Scherrer
+ */
+@EnableAspects(propagateRootCause = true)
+@ExtendWith(SpringExtension.class)
+@ContextConfiguration(classes = IntegrationLayerNotLoggedTest.TestConfig.class)
+class IntegrationLayerNotLoggedTest {
+
+    static class TestConfig {
+        @Bean
+        MyIntegrationComponent component() {
+            return new MyIntegrationComponent();
+        }
+    }
+
+    @Autowired
+    MyIntegrationComponent component;
+
+    @BeforeEach
+    public void clearLoggingStatements() {
+        LogCaptureAppender.clearEvents();
+    }
+
+    @Test void testNotLoggedIsSuppressed() {
+        try {
+            component.notLogged();
+            fail("Expected exception");
+        } catch (Exception ex) {
+            // expected
+        }
+        for (ILoggingEvent event : LogCaptureAppender.getEvents()) {
+            if (event.getMessage() != null && event.getMessage().contains("Should not appear")) {
+                fail("@NotLogged exception was logged by the integration aspect");
+            }
+        }
+    }
+
+    @Test void testPlainIsLogged() {
+        try {
+            component.logged();
+            fail("Expected exception");
+        } catch (Exception ex) {
+            // expected
+        }
+        for (ILoggingEvent event : LogCaptureAppender.getEvents()) {
+            if (event.getMessage() != null && event.getMessage().contains("Must be logged")) {
+                return;
+            }
+        }
+        fail("Plain exception was not logged by the integration aspect");
+    }
+
+    @Test void testNotLoggedInCauseChainIsSuppressed() {
+        try {
+            component.wrapsNotLogged();
+            fail("Expected exception");
+        } catch (Exception ex) {
+            // expected
+        }
+        for (ILoggingEvent event : LogCaptureAppender.getEvents()) {
+            if (event.getMessage() != null && event.getMessage().contains("wrapper of not-logged")) {
+                fail("Exception with @NotLogged in its cause chain was logged by the integration aspect");
+            }
+        }
+    }
+}
+
+@Repository
+class MyIntegrationComponent {
+    void notLogged() {
+        throw new MyIntegrationNotLoggedException("Should not appear");
+    }
+    void logged() {
+        throw new MyIntegrationException("Must be logged");
+    }
+    void wrapsNotLogged() {
+        throw new MyIntegrationException("wrapper of not-logged", new MyIntegrationNotLoggedException("inner"));
+    }
+}
+
+@NotLogged
+class MyIntegrationNotLoggedException extends RuntimeException {
+    MyIntegrationNotLoggedException(String message) {
+        super(message);
+    }
+}
+
+class MyIntegrationException extends RuntimeException {
+    MyIntegrationException(String message) {
+        super(message);
+    }
+    MyIntegrationException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/test/java/org/ameba/aop/IntegrationLayerNotLoggedTest.java
+++ b/src/test/java/org/ameba/aop/IntegrationLayerNotLoggedTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2005-2024 the original author or authors.
+ * Copyright 2005-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/ameba/aop/NotLoggedTest.java
+++ b/src/test/java/org/ameba/aop/NotLoggedTest.java
@@ -92,6 +92,20 @@ class NotLoggedTest {
             e.printStackTrace();
         }
     }
+
+    @Test void testNotLoggedInCauseChainIsSuppressed() {
+        try {
+            service.wrapsNotLogged();
+            fail("Expected exception");
+        } catch (Exception ex) {
+            // expected
+        }
+        for (ILoggingEvent next : LogCaptureAppender.getEvents()) {
+            if (next.getMessage() != null && next.getMessage().contains("wrapper of not-logged")) {
+                fail("Exception with @NotLogged in its cause chain was logged");
+            }
+        }
+    }
 }
 
 @TxService
@@ -101,6 +115,9 @@ class MyService {
     }
     void logged() {
         throw new MyException("Must be logged");
+    }
+    void wrapsNotLogged() {
+        throw new MyException("wrapper of not-logged", new MyNotLoggedException("inner"));
     }
 }
 
@@ -114,5 +131,8 @@ class MyNotLoggedException extends RuntimeException {
 class MyException extends RuntimeException {
     public MyException(String message) {
         super(message);
+    }
+    public MyException(String message, Throwable cause) {
+        super(message, cause);
     }
 }

--- a/src/test/java/org/ameba/aop/NotLoggedTest.java
+++ b/src/test/java/org/ameba/aop/NotLoggedTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2005-2024 the original author or authors.
+ * Copyright 2005-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/ameba/aop/PresentationLayerNotLoggedTest.java
+++ b/src/test/java/org/ameba/aop/PresentationLayerNotLoggedTest.java
@@ -1,0 +1,154 @@
+/*
+ * Copyright 2005-2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.ameba.aop;
+
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import org.ameba.annotation.EnableAspects;
+import org.ameba.annotation.NotLogged;
+import org.ameba.exception.BusinessRuntimeException;
+import org.ameba.test.LogCaptureAppender;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Bean;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.springframework.web.bind.annotation.RestController;
+
+import static org.junit.jupiter.api.Assertions.fail;
+
+/**
+ * A PresentationLayerNotLoggedTest verifies {@link NotLogged} suppression on the presentation layer.
+ *
+ * @author Heiko Scherrer
+ */
+@EnableAspects(propagateRootCause = true)
+@ExtendWith(SpringExtension.class)
+@ContextConfiguration(classes = PresentationLayerNotLoggedTest.TestConfig.class)
+class PresentationLayerNotLoggedTest {
+
+    static class TestConfig {
+        @Bean
+        MyController controller() {
+            return new MyController();
+        }
+    }
+
+    @Autowired
+    MyController controller;
+
+    @BeforeEach
+    public void clearLoggingStatements() {
+        LogCaptureAppender.clearEvents();
+    }
+
+    @Test void testNotLoggedIsSuppressed() {
+        try {
+            controller.notLogged();
+            fail("Expected exception");
+        } catch (Exception ex) {
+            // expected
+        }
+        for (ILoggingEvent event : LogCaptureAppender.getEvents()) {
+            if (event.getMessage() != null && event.getMessage().contains("Should not appear")) {
+                fail("@NotLogged exception was logged by the presentation aspect");
+            }
+        }
+    }
+
+    @Test void testPlainIsLogged() {
+        try {
+            controller.logged();
+            fail("Expected exception");
+        } catch (Exception ex) {
+            // expected
+        }
+        for (ILoggingEvent event : LogCaptureAppender.getEvents()) {
+            if (event.getMessage() != null && event.getMessage().contains("Must be logged")) {
+                return;
+            }
+        }
+        fail("Plain exception was not logged by the presentation aspect");
+    }
+
+    @Test void testNotLoggedInCauseChainIsSuppressed() {
+        try {
+            controller.wrapsNotLogged();
+            fail("Expected exception");
+        } catch (Exception ex) {
+            // expected
+        }
+        for (ILoggingEvent event : LogCaptureAppender.getEvents()) {
+            if (event.getMessage() != null && event.getMessage().contains("wrapper of not-logged")) {
+                fail("Exception with @NotLogged in its cause chain was logged by the presentation aspect");
+            }
+        }
+    }
+
+    @Test void testNotLoggedBusinessRuntimeExceptionIsSuppressed() {
+        try {
+            controller.notLoggedBusiness();
+            fail("Expected exception");
+        } catch (Exception ex) {
+            // expected
+        }
+        for (ILoggingEvent event : LogCaptureAppender.getEvents()) {
+            if (event.getMessage() != null && event.getMessage().contains("Should not appear as BRE")) {
+                fail("@NotLogged BusinessRuntimeException was logged by the presentation aspect");
+            }
+        }
+    }
+}
+
+@RestController
+class MyController {
+    public void notLogged() {
+        throw new MyPresentationNotLoggedException("Should not appear");
+    }
+    public void logged() {
+        throw new MyPresentationException("Must be logged");
+    }
+    public void wrapsNotLogged() {
+        throw new MyPresentationException("wrapper of not-logged", new MyPresentationNotLoggedException("inner"));
+    }
+    public void notLoggedBusiness() {
+        throw new MyNotLoggedBusinessException("Should not appear as BRE");
+    }
+}
+
+@NotLogged
+class MyPresentationNotLoggedException extends RuntimeException {
+    MyPresentationNotLoggedException(String message) {
+        super(message);
+    }
+}
+
+class MyPresentationException extends RuntimeException {
+    MyPresentationException(String message) {
+        super(message);
+    }
+    MyPresentationException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}
+
+@NotLogged
+class MyNotLoggedBusinessException extends BusinessRuntimeException {
+    MyNotLoggedBusinessException(String message) {
+        super(message);
+    }
+}

--- a/src/test/java/org/ameba/aop/PresentationLayerNotLoggedTest.java
+++ b/src/test/java/org/ameba/aop/PresentationLayerNotLoggedTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2005-2024 the original author or authors.
+ * Copyright 2005-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/ameba/integration/hibernate/HibernateITConfig.java
+++ b/src/test/java/org/ameba/integration/hibernate/HibernateITConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2024 the original author or authors.
+ * Copyright 2015-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/ameba/integration/hibernate/HibernateSchemaBasedTenancyConfigurationTest.java
+++ b/src/test/java/org/ameba/integration/hibernate/HibernateSchemaBasedTenancyConfigurationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2024 the original author or authors.
+ * Copyright 2015-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/ameba/integration/hibernate/TestEntity.java
+++ b/src/test/java/org/ameba/integration/hibernate/TestEntity.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2024 the original author or authors.
+ * Copyright 2015-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/ameba/integration/hibernate/TransactionalService.java
+++ b/src/test/java/org/ameba/integration/hibernate/TransactionalService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2024 the original author or authors.
+ * Copyright 2015-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/ameba/integration/hibernate/TransactionalServiceImpl.java
+++ b/src/test/java/org/ameba/integration/hibernate/TransactionalServiceImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2024 the original author or authors.
+ * Copyright 2015-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/ameba/integration/jpa/ApplicationEntityIT.java
+++ b/src/test/java/org/ameba/integration/jpa/ApplicationEntityIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2024 the original author or authors.
+ * Copyright 2015-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/ameba/integration/jpa/BaseEntityIT.java
+++ b/src/test/java/org/ameba/integration/jpa/BaseEntityIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2024 the original author or authors.
+ * Copyright 2015-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/ameba/integration/jpa/BaseEntityTest.java
+++ b/src/test/java/org/ameba/integration/jpa/BaseEntityTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2024 the original author or authors.
+ * Copyright 2015-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/ameba/integration/jpa/JPAITConfig.java
+++ b/src/test/java/org/ameba/integration/jpa/JPAITConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2024 the original author or authors.
+ * Copyright 2015-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/ameba/integration/jpa/TestApplicationEntity.java
+++ b/src/test/java/org/ameba/integration/jpa/TestApplicationEntity.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2024 the original author or authors.
+ * Copyright 2015-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/ameba/integration/jpa/TestEntity.java
+++ b/src/test/java/org/ameba/integration/jpa/TestEntity.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2024 the original author or authors.
+ * Copyright 2015-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/ameba/integration/jpa/TestFailApplicationEntity.java
+++ b/src/test/java/org/ameba/integration/jpa/TestFailApplicationEntity.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2024 the original author or authors.
+ * Copyright 2015-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/ameba/integration/mongodb/AbstractMongoDBIntegrationTests.java
+++ b/src/test/java/org/ameba/integration/mongodb/AbstractMongoDBIntegrationTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2024 the original author or authors.
+ * Copyright 2015-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/ameba/integration/mongodb/BaseEntityTest.java
+++ b/src/test/java/org/ameba/integration/mongodb/BaseEntityTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2024 the original author or authors.
+ * Copyright 2015-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/ameba/integration/mongodb/TestDocument.java
+++ b/src/test/java/org/ameba/integration/mongodb/TestDocument.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2024 the original author or authors.
+ * Copyright 2015-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/ameba/test/AspectJExtension.java
+++ b/src/test/java/org/ameba/test/AspectJExtension.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2024 the original author or authors.
+ * Copyright 2015-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/ameba/test/LogCaptureAppender.java
+++ b/src/test/java/org/ameba/test/LogCaptureAppender.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2005-2024 the original author or authors.
+ * Copyright 2005-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/ameba/test/MockitoExtension.java
+++ b/src/test/java/org/ameba/test/MockitoExtension.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2024 the original author or authors.
+ * Copyright 2015-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/ameba/test/categories/IntegrationTests.java
+++ b/src/test/java/org/ameba/test/categories/IntegrationTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2024 the original author or authors.
+ * Copyright 2015-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/ameba/test/categories/SpringTestSupport.java
+++ b/src/test/java/org/ameba/test/categories/SpringTestSupport.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2005-2024 the original author or authors.
+ * Copyright 2005-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/ameba/test/categories/UnitTests.java
+++ b/src/test/java/org/ameba/test/categories/UnitTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2024 the original author or authors.
+ * Copyright 2015-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/resources/logback-test.xml
+++ b/src/test/resources/logback-test.xml
@@ -10,6 +10,14 @@
         <appender-ref ref="CAP"/>
         <appender-ref ref="STDOUT"/>
     </logger>
+    <logger name="INTEGRATION_LAYER_EXCEPTION" level="ERROR">
+        <appender-ref ref="CAP"/>
+        <appender-ref ref="STDOUT"/>
+    </logger>
+    <logger name="PRESENTATION_LAYER_EXCEPTION" level="ERROR">
+        <appender-ref ref="CAP"/>
+        <appender-ref ref="STDOUT"/>
+    </logger>
 
     <root level="ERROR">
         <appender-ref ref="CAP" />

--- a/src/test/resources/logback-test.xml
+++ b/src/test/resources/logback-test.xml
@@ -6,15 +6,15 @@
     <appender name="CAP" class="org.ameba.test.LogCaptureAppender" />
     <statusListener class="ch.qos.logback.core.status.NopStatusListener" />
 
-    <logger name="SERVICE_LAYER_EXCEPTION" level="ERROR">
+    <logger name="SERVICE_LAYER_EXCEPTION" level="ERROR" additivity="false">
         <appender-ref ref="CAP"/>
         <appender-ref ref="STDOUT"/>
     </logger>
-    <logger name="INTEGRATION_LAYER_EXCEPTION" level="ERROR">
+    <logger name="INTEGRATION_LAYER_EXCEPTION" level="ERROR" additivity="false">
         <appender-ref ref="CAP"/>
         <appender-ref ref="STDOUT"/>
     </logger>
-    <logger name="PRESENTATION_LAYER_EXCEPTION" level="ERROR">
+    <logger name="PRESENTATION_LAYER_EXCEPTION" level="ERROR" additivity="false">
         <appender-ref ref="CAP"/>
         <appender-ref ref="STDOUT"/>
     </logger>


### PR DESCRIPTION
## Summary

- Fix inverted `@NotLogged` check in `IntegrationLayerAspect` and `PresentationLayerAspect` — they logged **only** `@NotLogged` exceptions and dropped every other one. `ServiceLayerAspect` was correct and is refactored to use the shared helper.
- Extract `AspectSupport.hasNotLogged(Throwable)` so all three layer aspects use the same predicate. It walks the full cause chain, so a `@NotLogged` exception wrapped inside another exception is also suppressed.
- Mark `@NotLogged` as `@Inherited` so subclasses of a `@NotLogged` base exception inherit the suppression automatically.
- New tests:
  - `AspectSupportTest` — 5 unit tests pinning the predicate's contract (direct, none, cause-depth-1, deep cause chain, inheritance).
  - `IntegrationLayerNotLoggedTest` / `PresentationLayerNotLoggedTest` — integration coverage of the previously-untested aspects, including cause-chain and (for presentation) `@NotLogged` on a `BusinessRuntimeException`.
  - `NotLoggedTest` — added a cause-chain case.
- `logback-test.xml` — route `INTEGRATION_LAYER_EXCEPTION` and `PRESENTATION_LAYER_EXCEPTION` to the capture appender (they're `additivity="false"` in production, so tests need explicit routing).
- README — documented the new semantics of `@NotLogged`.

## Why the diff looks enormous

Most of the 188 touched files are a copyright-header year bump (`2024` → `2026`) applied in a separate commit (`877b558`). Only ~10 files carry substantive changes — see the commit-level diffs for `9224b99` and `ab4b34d`.

## Test plan

- [x] `./mvnw test` — 19/19 pass, including 9 new tests for `@NotLogged`.
- [x] `NotLoggedTest` (service) — unchanged behavior, `@NotLogged` still suppressed.
- [x] `IntegrationLayerNotLoggedTest` — now verifies plain exceptions are logged AND `@NotLogged` is suppressed (previously both behaviors were broken).
- [x] `PresentationLayerNotLoggedTest` — same, plus the `BusinessRuntimeException` branch.
- [x] Cause-chain test per aspect — `RuntimeException` wrapping a `@NotLogged` cause is suppressed at all three tiers.