### PR TITLE
Add tests for Response and oauth2, fix latent bugs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -54,7 +54,6 @@
         <jakarta-servlet.version>6.1.0</jakarta-servlet.version> <!-- in line with boot -->
         <jakarta.persistence-api.version>3.2.0</jakarta.persistence-api.version> <!-- in line with boot / hibernate-core -->
         <jakarta.validation-api.version>3.1.1</jakarta.validation-api.version> <!-- in line with hibernate-validator-parent -->
-        <json-path.version>2.10.0</json-path.version> <!-- in line with boot -->
         <jjwt.version>0.12.6</jjwt.version>
         <jwks-rsa.version>0.22.2</jwks-rsa.version>
         <logback.version>1.5.32</logback.version> <!-- in line with boot -->
@@ -374,8 +373,8 @@
             <optional>true</optional>
         </dependency>
         <dependency>
-            <groupId>com.jayway.jsonpath</groupId>
-            <artifactId>json-path</artifactId>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
             <scope>provided</scope>
             <optional>true</optional>
         </dependency>
@@ -624,11 +623,6 @@
                 <groupId>com.fasterxml.jackson.core</groupId>
                 <artifactId>jackson-annotations</artifactId>
                 <version>${jackson.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>com.jayway.jsonpath</groupId>
-                <artifactId>json-path</artifactId>
-                <version>${json-path.version}</version>
             </dependency>
             <dependency>
                 <groupId>com.github.dozermapper</groupId>

--- a/src/main/java/org/ameba/http/Response.java
+++ b/src/main/java/org/ameba/http/Response.java
@@ -18,16 +18,18 @@ package org.ameba.http;
 import com.fasterxml.jackson.annotation.JsonAnyGetter;
 import com.fasterxml.jackson.annotation.JsonAnySetter;
 import com.fasterxml.jackson.annotation.JsonInclude;
-import com.jayway.jsonpath.Configuration;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.springframework.hateoas.RepresentationModel;
 
 import java.io.Serializable;
+import java.lang.reflect.Array;
 import java.text.ParseException;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
-
-import static com.jayway.jsonpath.JsonPath.read;
 
 /**
  * An instance of Response is a transfer object that is used to encapsulate a server response to the client application.
@@ -71,25 +73,49 @@ public class Response<T extends Serializable> extends RepresentationModel<Respon
         httpStatus = builder.httpStatus;
     }
 
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
     /**
      * Checks whether all mandatory fields are set on the String passed as {@literal s} and parses this String into a
-     * valid instance.
+     * valid instance. The {@literal componentType} is required to materialise the {@code obj} array at runtime because
+     * Java generics erase the element type of {@code T[]}.
      *
      * @param s The String to get the mandatory fields from
+     * @param componentType The runtime component type used to build the {@code obj} array
      * @return The instance
      * @throws ParseException In case the given String didn't match
      */
-    public static <T extends Serializable> Response<T> parse(String s) throws ParseException {
-        if (s.contains("message") &&
-                s.contains("messageKey") &&
-                s.contains("httpStatus") &&
-                s.contains(CLASS)) {
-            var d = Configuration.defaultConfiguration().jsonProvider().parse(s);
-            String[] obj = read(d, "$.obj");
-            var r = new Response<>(read(d, "$.message"), read(d, "$.messageKey"), read(d, "$.httpStatus"), obj);
-            r.any();
+    @SuppressWarnings("unchecked")
+    public static <T extends Serializable> Response<T> parse(String s, Class<T> componentType) throws ParseException {
+        JsonNode tree;
+        try {
+            tree = MAPPER.readTree(s);
+        } catch (JsonProcessingException e) {
+            throw (ParseException) new ParseException(String.format("Invalid JSON. [%s]", s), -1).initCause(e);
         }
-        throw new ParseException(String.format("String does not contain mandatory fields. [%s]", s), -1);
+        if (!tree.has("message") || !tree.has("messageKey") || !tree.has("httpStatus") || !tree.has(CLASS)) {
+            throw new ParseException(String.format("String does not contain mandatory fields. [%s]", s), -1);
+        }
+        var objList = new ArrayList<T>();
+        var objNode = tree.get("obj");
+        if (objNode != null && objNode.isArray()) {
+            for (var elem : objNode) {
+                try {
+                    objList.add(MAPPER.treeToValue(elem, componentType));
+                } catch (JsonProcessingException e) {
+                    throw (ParseException) new ParseException(String.format("Cannot convert obj element. [%s]", elem), -1).initCause(e);
+                }
+            }
+        }
+        var empty = (T[]) Array.newInstance(componentType, 0);
+        var obj = objList.isEmpty() ? null : objList.toArray(empty);
+        var r = new Response<>(
+                tree.path("message").asText(null),
+                tree.path("messageKey").asText(null),
+                tree.path("httpStatus").asText(null),
+                obj);
+        r.any();
+        return r;
     }
 
     public static <T extends Serializable> Builder<T> newBuilder() {

--- a/src/main/java/org/ameba/oauth2/BearerTokenExtractor.java
+++ b/src/main/java/org/ameba/oauth2/BearerTokenExtractor.java
@@ -37,13 +37,22 @@ public class BearerTokenExtractor extends DefaultTokenExtractor {
      */
     @Override
     public ExtractionResult canExtract(String authHeader) {
-        String token = stripBearer(authHeader);
-        String[] parts = token.split("\\.");
-        return authHeader.startsWith("Bearer ") && parts.length == 3 ? new ExtractionResult() : new ExtractionResult("Not a valid JWT");
+        if (authHeader == null) {
+            return new ExtractionResult("No Authorization header");
+        }
+        if (!authHeader.startsWith("Bearer ")) {
+            return new ExtractionResult("Not a valid JWT");
+        }
+        var token = stripBearer(authHeader);
+        var parts = token.split("\\.");
+        if (parts.length != 3 || token.indexOf(' ') >= 0) {
+            return new ExtractionResult("Not a valid JWT");
+        }
+        return new ExtractionResult();
     }
 
     private String stripBearer(String authHeader) {
-        return authHeader.replace("Bearer ", "");
+        return authHeader.startsWith("Bearer ") ? authHeader.substring("Bearer ".length()) : authHeader;
     }
 
     /**

--- a/src/main/java/org/ameba/oauth2/DefaultTokenExtractor.java
+++ b/src/main/java/org/ameba/oauth2/DefaultTokenExtractor.java
@@ -67,14 +67,14 @@ public class DefaultTokenExtractor implements TokenExtractor {
     }
 
     private void ensureTokenNotExpired(JsonNode tokenPayload) {
-        long nowTime = new Date().getTime();
-        var exp = tokenPayload.get("exp").isNull() ? null : new Date(tokenPayload.get("exp").asLong() * 1000);
-        if (exp != null) {
-            var maxTime = nowTime - Issuer.DEFAULT_MAX_SKEW_SECONDS;
-            var max = new Date(maxTime);
-            if (max.after(exp)) {
-                throw new InvalidTokenException("Token has expired");
-            }
+        var expNode = tokenPayload.path("exp");
+        if (expNode.isMissingNode() || expNode.isNull()) {
+            return;
+        }
+        var exp = new Date(expNode.asLong() * 1000);
+        var maxTime = new Date().getTime() - Issuer.DEFAULT_MAX_SKEW_SECONDS;
+        if (new Date(maxTime).after(exp)) {
+            throw new InvalidTokenException("Token has expired");
         }
     }
 
@@ -94,13 +94,17 @@ public class DefaultTokenExtractor implements TokenExtractor {
 
         ensureTokenNotExpired(tokenPayload);
 
+        var issNode = tokenPayload.path("iss");
+        if (issNode.isMissingNode() || issNode.isNull() || issNode.asText().isEmpty()) {
+            throw new InvalidTokenException("Missing iss claim");
+        }
+        var iss = issNode.asText();
+
         Issuer issuer;
         if (tokenHeader.has("kid")) {
-
-            issuer = whiteList.getIssuer(tokenPayload.get("iss").asText(), tokenHeader.get("kid").asText());
+            issuer = whiteList.getIssuer(iss, tokenHeader.get("kid").asText());
         } else {
-
-            var issuers = whiteList.getIssuers(tokenPayload.get("iss").asText());
+            var issuers = whiteList.getIssuers(iss);
             // Okay, the issuer seems to have multiple kids for the same issuer ID, so take the first one...
             issuer = issuers.isEmpty() ? null : issuers.getFirst();
         }

--- a/src/main/java/org/ameba/oauth2/parser/HS512TokenParser.java
+++ b/src/main/java/org/ameba/oauth2/parser/HS512TokenParser.java
@@ -17,7 +17,8 @@ package org.ameba.oauth2.parser;
 
 import io.jsonwebtoken.Jwt;
 import io.jsonwebtoken.Jwts;
-import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.io.Decoders;
+import io.jsonwebtoken.security.Keys;
 import org.ameba.oauth2.InvalidTokenException;
 import org.ameba.oauth2.Symmetric;
 import org.ameba.oauth2.TokenParser;
@@ -25,7 +26,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * A HS256TokenParser uses a symmetric SHA-512 signing key to verify the signature.
+ * A HS512TokenParser uses a symmetric SHA-512 signing key to verify the signature.
  *
  * @author Heiko Scherrer
  */
@@ -38,7 +39,7 @@ public class HS512TokenParser implements TokenParser<Symmetric, Jwt> {
      */
     @Override
     public String supportAlgorithm() {
-        return SignatureAlgorithm.HS512.toString();
+        return Jwts.SIG.HS512.getId();
     }
 
     /**
@@ -49,17 +50,16 @@ public class HS512TokenParser implements TokenParser<Symmetric, Jwt> {
         if (issuer == null) {
             throw new IllegalArgumentException("Expected symmetric issuer is null");
         }
-        if (issuer.getSigningKey() == null || "".equals(issuer.getSigningKey())) {
+        if (issuer.getSigningKey() == null || issuer.getSigningKey().isEmpty()) {
             throw new IllegalArgumentException("Symmetric signing key is null or empty. Configure a signing key");
         }
-
-        Jwt jwt;
         try {
-            jwt = Jwts.parser()
+            var key = Keys.hmacShaKeyFor(Decoders.BASE64.decode(issuer.getSigningKey()));
+            return Jwts.parser()
                     .clockSkewSeconds(issuer.getSkewSeconds())
-                    .setSigningKey(issuer.getSigningKey())
-                    .build().parseClaimsJws(token);
-            return jwt;
+                    .verifyWith(key)
+                    .build()
+                    .parseSignedClaims(token);
         } catch (Exception e) {
             LOGGER.error(e.getMessage(), e);
             throw new InvalidTokenException(e.getMessage());

--- a/src/main/java/org/ameba/oauth2/parser/RSA256TokenParser.java
+++ b/src/main/java/org/ameba/oauth2/parser/RSA256TokenParser.java
@@ -15,13 +15,11 @@
  */
 package org.ameba.oauth2.parser;
 
-import com.auth0.jwk.Jwk;
 import com.auth0.jwk.JwkProvider;
 import com.auth0.jwk.UrlJwkProvider;
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.Jws;
 import io.jsonwebtoken.Jwts;
-import io.jsonwebtoken.SignatureAlgorithm;
 import org.ameba.oauth2.Asymmetric;
 import org.ameba.oauth2.InvalidTokenException;
 import org.ameba.oauth2.TokenParser;
@@ -31,8 +29,6 @@ import org.slf4j.LoggerFactory;
 import java.security.KeyFactory;
 import java.security.PublicKey;
 import java.security.spec.X509EncodedKeySpec;
-
-import static java.lang.String.format;
 
 /**
  * A RSA256TokenParser uses a SHA-256 Public Key to verify signature.
@@ -55,7 +51,7 @@ public class RSA256TokenParser implements TokenParser<Asymmetric, Jws<Claims>> {
      */
     @Override
     public String supportAlgorithm() {
-        return SignatureAlgorithm.RS256.toString();
+        return Jwts.SIG.RS256.getId();
     }
 
     /**
@@ -66,26 +62,25 @@ public class RSA256TokenParser implements TokenParser<Asymmetric, Jws<Claims>> {
         if (issuer == null) {
             throw new IllegalArgumentException("Expected asymmetric issuer is null");
         }
-        if (issuer.getKID() == null || "".equals(issuer.getKID())) {
+        if (issuer.getKID() == null || issuer.getKID().isEmpty()) {
             throw new IllegalArgumentException("JWK kid is null or empty. Configure a kid");
         }
-        Jws<Claims> jws;
         try {
             if (LOGGER.isDebugEnabled()) {
-                LOGGER.debug(format("Checking issuer with KID [%s]", issuer.getKID()));
+                LOGGER.debug("Checking issuer with KID [{}]", issuer.getKID());
             }
-            Jwk jwk = jwkProvider == null
+            var jwk = jwkProvider == null
                     ? new UrlJwkProvider(issuer.getJWKURL(), 60000, 60000).get(issuer.getKID())
                     : jwkProvider.get(issuer.getKID());
-            byte[] publicKeyBytes = jwk.getPublicKey().getEncoded();
-            X509EncodedKeySpec keySpec = new X509EncodedKeySpec(publicKeyBytes);
-            KeyFactory keyFactory = KeyFactory.getInstance("RSA");
+            var publicKeyBytes = jwk.getPublicKey().getEncoded();
+            var keySpec = new X509EncodedKeySpec(publicKeyBytes);
+            var keyFactory = KeyFactory.getInstance("RSA");
             PublicKey pubKey = keyFactory.generatePublic(keySpec);
-            jws = Jwts.parser()
-                    .setAllowedClockSkewSeconds(issuer.getSkewSeconds())
-                    .setSigningKey(pubKey)
-                    .build().parseClaimsJws(token);
-            return jws;
+            return Jwts.parser()
+                    .clockSkewSeconds(issuer.getSkewSeconds())
+                    .verifyWith(pubKey)
+                    .build()
+                    .parseSignedClaims(token);
         } catch (Exception e) {
             LOGGER.error(e.getMessage(), e);
             throw new InvalidTokenException(e.getMessage());

--- a/src/test/java/org/ameba/http/ResponseTest.java
+++ b/src/test/java/org/ameba/http/ResponseTest.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright 2015-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.ameba.http;
+
+import org.junit.jupiter.api.Test;
+
+import java.text.ParseException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * A ResponseTest verifies the {@link Response} HTTP envelope: builder semantics, equality,
+ * the {@code getFirst}/{@code getAny} accessors and the {@link Response#parse(String)} contract.
+ *
+ * @author Heiko Scherrer
+ */
+class ResponseTest {
+
+    @Test void builderPopulatesAllFields() {
+        var testee = Response.<String>newBuilder()
+                .withMessage("ok")
+                .withMessageKey("M.OK")
+                .withHttpStatus("200")
+                .withObj("a", "b")
+                .build();
+
+        assertThat(testee.getMessage()).isEqualTo("ok");
+        assertThat(testee.getMessageKey()).isEqualTo("M.OK");
+        assertThat(testee.getHttpStatus()).isEqualTo("200");
+        assertThat(testee.getObj()).containsExactly("a", "b");
+    }
+
+    @Test void newBuilderReturnsFreshInstances() {
+        assertThat(Response.newBuilder()).isNotSameAs(Response.newBuilder());
+    }
+
+    @Test void getFirstReturnsNullWhenObjMissing() {
+        var empty = Response.<String>newBuilder().build();
+        var withEmptyArray = Response.<String>newBuilder().withObj(new String[0]).build();
+
+        assertThat(empty.getObj()).isNull();
+        assertThat(withEmptyArray.getObj()).isEmpty();
+    }
+
+    @Test void getAnyRejectsNullKey() {
+        var testee = Response.<String>newBuilder().build();
+
+        assertThatThrownBy(() -> testee.getAny(null))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("key");
+    }
+
+    @Test void equalsAndHashCodeRespectAllFields() {
+        var a = Response.<String>newBuilder().withMessage("m").withMessageKey("k").withHttpStatus("200").withObj("x").build();
+        var b = Response.<String>newBuilder().withMessage("m").withMessageKey("k").withHttpStatus("200").withObj("x").build();
+        var different = Response.<String>newBuilder().withMessage("m").withMessageKey("k").withHttpStatus("500").withObj("x").build();
+
+        assertThat(a).isEqualTo(b).hasSameHashCodeAs(b);
+        assertThat(a).isNotEqualTo(different);
+    }
+
+    @Test void toStringContainsKeyFields() {
+        var testee = Response.<String>newBuilder().withMessage("m").withMessageKey("k").withHttpStatus("200").withObj("x").build();
+
+        assertThat(testee.toString()).contains("m", "k", "200", "x");
+    }
+
+    @Test void parseReturnsResponseForValidInput() throws ParseException {
+        var json = "{\"message\":\"ok\",\"messageKey\":\"M.OK\",\"httpStatus\":\"200\",\"class\":\"String\",\"obj\":[\"x\"]}";
+
+        var parsed = Response.parse(json, String.class);
+
+        assertThat(parsed.getMessage()).isEqualTo("ok");
+        assertThat(parsed.getMessageKey()).isEqualTo("M.OK");
+        assertThat(parsed.getHttpStatus()).isEqualTo("200");
+        assertThat(parsed.getObj()).containsExactly("x");
+    }
+
+    @Test void parseThrowsOnMissingMandatoryFields() {
+        assertThatThrownBy(() -> Response.parse("{}", String.class))
+                .isInstanceOf(ParseException.class)
+                .hasMessageContaining("mandatory fields");
+    }
+}

--- a/src/test/java/org/ameba/oauth2/BearerTokenExtractorTest.java
+++ b/src/test/java/org/ameba/oauth2/BearerTokenExtractorTest.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2015-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.ameba.oauth2;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * A BearerTokenExtractorTest pins the {@code canExtract} contract for Bearer authorization headers.
+ * Tests for the deeper {@code extract} path (which delegates to {@link DefaultTokenExtractor}) are
+ * intentionally kept separate so that crypto/whitelist concerns are not mixed with header-shape checks.
+ *
+ * @author Heiko Scherrer
+ */
+class BearerTokenExtractorTest {
+
+    private final BearerTokenExtractor testee = new BearerTokenExtractor(null, List.of());
+
+    @Test void canExtractAcceptsWellFormedBearerJwt() {
+        var result = testee.canExtract("Bearer aaa.bbb.ccc");
+
+        assertThat(result.isExtractionPossible()).isTrue();
+        assertThat(result.getReason()).isNull();
+    }
+
+    @Test void canExtractRejectsHeaderWithoutBearerPrefix() {
+        var result = testee.canExtract("NotBearer aaa.bbb.ccc");
+
+        assertThat(result.isExtractionPossible()).isFalse();
+        assertThat(result.getReason()).isEqualTo("Not a valid JWT");
+    }
+
+    @Test void canExtractIsCaseSensitiveOnBearer() {
+        assertThat(testee.canExtract("bearer aaa.bbb.ccc").isExtractionPossible()).isFalse();
+        assertThat(testee.canExtract("BEARER aaa.bbb.ccc").isExtractionPossible()).isFalse();
+    }
+
+    @Test void canExtractRejectsTokensWithWrongNumberOfParts() {
+        assertThat(testee.canExtract("Bearer aaa").isExtractionPossible()).isFalse();
+        assertThat(testee.canExtract("Bearer aaa.bbb").isExtractionPossible()).isFalse();
+        assertThat(testee.canExtract("Bearer aaa.bbb.ccc.ddd").isExtractionPossible()).isFalse();
+    }
+
+    @Test void canExtractRejectsBearerWithEmptyToken() {
+        // "Bearer " alone strips to "" which splits to a single empty element.
+        assertThat(testee.canExtract("Bearer ").isExtractionPossible()).isFalse();
+    }
+
+    @Test void canExtractReturnsCleanFailureForNullHeader() {
+        var result = testee.canExtract(null);
+
+        assertThat(result.isExtractionPossible()).isFalse();
+        assertThat(result.getReason()).isEqualTo("No Authorization header");
+    }
+
+    @Test void extractThrowsInvalidTokenForNullHeader() {
+        assertThatThrownBy(() -> testee.extract(null))
+                .isInstanceOf(InvalidTokenException.class)
+                .hasMessageContaining("Not a valid Bearer token");
+    }
+
+    @Test void canExtractRejectsDoubleBearerHeader() {
+        var result = testee.canExtract("Bearer Bearer aaa.bbb.ccc");
+
+        assertThat(result.isExtractionPossible()).isFalse();
+        assertThat(result.getReason()).isEqualTo("Not a valid JWT");
+    }
+}

--- a/src/test/java/org/ameba/oauth2/DefaultTokenExtractorTest.java
+++ b/src/test/java/org/ameba/oauth2/DefaultTokenExtractorTest.java
@@ -1,0 +1,185 @@
+/*
+ * Copyright 2015-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.ameba.oauth2;
+
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.io.Encoders;
+import io.jsonwebtoken.security.Keys;
+import org.ameba.oauth2.parser.HS512TokenParser;
+import org.junit.jupiter.api.Test;
+
+import java.net.URL;
+import java.security.SecureRandom;
+import java.util.Date;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * A DefaultTokenExtractorTest exercises the orchestration between JWT parsing,
+ * issuer whitelisting and signature verification. The happy path uses the real
+ * {@link HS512TokenParser} paired with a hand-rolled in-memory whitelist so that
+ * the extractor is tested end-to-end without Mockito or network IO.
+ *
+ * @author Heiko Scherrer
+ */
+class DefaultTokenExtractorTest {
+
+    private static final String ISSUER_ID = "test-issuer";
+
+    @Test void canExtractAcceptsThreePartToken() {
+        var testee = newExtractor("unused", randomKeyBase64());
+
+        assertThat(testee.canExtract("a.b.c").isExtractionPossible()).isTrue();
+    }
+
+    @Test void canExtractRejectsTokensWithWrongNumberOfParts() {
+        var testee = newExtractor(ISSUER_ID, randomKeyBase64());
+
+        assertThat(testee.canExtract("a").isExtractionPossible()).isFalse();
+        assertThat(testee.canExtract("a.b").isExtractionPossible()).isFalse();
+        assertThat(testee.canExtract("a.b.c.d").isExtractionPossible()).isFalse();
+    }
+
+    @Test void extractRejectsTokenWithFewerThanTwoParts() {
+        var testee = newExtractor(ISSUER_ID, randomKeyBase64());
+
+        assertThatThrownBy(() -> testee.extract("only-one-part"))
+                .isInstanceOf(InvalidTokenException.class)
+                .hasMessageContaining("Token is not a JWT");
+    }
+
+    @Test void extractReturnsJwtForValidSignedToken() {
+        var keyBytes = randomKeyBytes();
+        var base64Key = Encoders.BASE64.encode(keyBytes);
+        var token = Jwts.builder()
+                .subject("test-user")
+                .issuer(ISSUER_ID)
+                .expiration(oneHourFromNow())
+                .signWith(Keys.hmacShaKeyFor(keyBytes))
+                .compact();
+        var testee = newExtractor(ISSUER_ID, base64Key);
+
+        var result = testee.extract(token);
+
+        assertThat(result.isExtractionPossible()).isTrue();
+        assertThat(result.hasJwt()).isTrue();
+    }
+
+    @Test void extractRejectsTokenWithUnknownIssuer() {
+        var keyBytes = randomKeyBytes();
+        var base64Key = Encoders.BASE64.encode(keyBytes);
+        var token = Jwts.builder()
+                .subject("x")
+                .issuer("some-other-issuer")
+                .expiration(oneHourFromNow())
+                .signWith(Keys.hmacShaKeyFor(keyBytes))
+                .compact();
+        var testee = newExtractor(ISSUER_ID, base64Key);
+
+        assertThatThrownBy(() -> testee.extract(token))
+                .isInstanceOf(InvalidTokenException.class)
+                .hasMessageContaining("Issuer not accepted");
+    }
+
+    @Test void extractRejectsTokenWithUnsupportedAlgorithm() {
+        // Sign with HS384 but only register an HS512 parser — should fail with "Algorithm not supported".
+        var keyBytes = new byte[48]; // HS384 min key size
+        new SecureRandom().nextBytes(keyBytes);
+        var base64Key = Encoders.BASE64.encode(keyBytes);
+        var token = Jwts.builder()
+                .subject("x")
+                .issuer(ISSUER_ID)
+                .expiration(oneHourFromNow())
+                .signWith(Keys.hmacShaKeyFor(keyBytes), Jwts.SIG.HS384)
+                .compact();
+        var testee = newExtractor(ISSUER_ID, base64Key);
+
+        assertThatThrownBy(() -> testee.extract(token))
+                .isInstanceOf(InvalidTokenException.class)
+                .hasMessageContaining("Algorithm [HS384] not supported");
+    }
+
+    @Test void extractAcceptsTokenWithoutExpClaim() {
+        // A JWT without exp is still accepted — some APIs issue non-expiring tokens deliberately.
+        var keyBytes = randomKeyBytes();
+        var base64Key = Encoders.BASE64.encode(keyBytes);
+        var token = Jwts.builder()
+                .subject("x")
+                .issuer(ISSUER_ID)
+                .signWith(Keys.hmacShaKeyFor(keyBytes))
+                .compact();
+        var testee = newExtractor(ISSUER_ID, base64Key);
+
+        var result = testee.extract(token);
+
+        assertThat(result.hasJwt()).isTrue();
+    }
+
+    @Test void extractRejectsTokenWithoutIssClaim() {
+        var keyBytes = randomKeyBytes();
+        var token = Jwts.builder()
+                .subject("x")
+                .expiration(oneHourFromNow())
+                .signWith(Keys.hmacShaKeyFor(keyBytes))
+                .compact();
+        var testee = newExtractor(ISSUER_ID, Encoders.BASE64.encode(keyBytes));
+
+        assertThatThrownBy(() -> testee.extract(token))
+                .isInstanceOf(InvalidTokenException.class)
+                .hasMessageContaining("Missing iss claim");
+    }
+
+    private static DefaultTokenExtractor newExtractor(String issuerId, String base64SigningKey) {
+        IssuerWhiteList<Issuer> whiteList = new IssuerWhiteList<>() {
+            @Override
+            public List<Issuer> getIssuers(String iss) {
+                if (!issuerId.equals(iss)) {
+                    return List.of();
+                }
+                return List.of(new TestSymmetric(issuerId, base64SigningKey));
+            }
+
+            @Override
+            public Issuer getIssuer(String iss, String kid) {
+                throw new UnsupportedOperationException("kid branch not exercised by these tests");
+            }
+        };
+        return new DefaultTokenExtractor(whiteList, List.of(new HS512TokenParser()));
+    }
+
+    private static byte[] randomKeyBytes() {
+        var bytes = new byte[64];
+        new SecureRandom().nextBytes(bytes);
+        return bytes;
+    }
+
+    private static String randomKeyBase64() {
+        return Encoders.BASE64.encode(randomKeyBytes());
+    }
+
+    private static Date oneHourFromNow() {
+        return new Date(System.currentTimeMillis() + 3_600_000L);
+    }
+
+    private record TestSymmetric(String issuerId, String signingKey) implements Symmetric {
+        @Override public String getSigningKey() { return signingKey; }
+        @Override public String getIssuerId() { return issuerId; }
+        @Override public long getSkewSeconds() { return Issuer.DEFAULT_MAX_SKEW_SECONDS; }
+        @Override public URL getBaseURL() { return null; }
+    }
+}

--- a/src/test/java/org/ameba/oauth2/issuer/ConfigurationIssuerWhiteListTest.java
+++ b/src/test/java/org/ameba/oauth2/issuer/ConfigurationIssuerWhiteListTest.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright 2015-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.ameba.oauth2.issuer;
+
+import org.ameba.oauth2.InvalidTokenException;
+import org.ameba.oauth2.Issuer;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.context.properties.source.InvalidConfigurationPropertyValueException;
+
+import java.net.URI;
+import java.net.URL;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * A ConfigurationIssuerWhiteListTest pins the matching semantics of the property-driven
+ * issuer whitelist (issuer-id and kid both must match) and the fast-fail behaviour of the
+ * constructor when a malformed baseURL slips through Spring property binding.
+ *
+ * @author Heiko Scherrer
+ */
+class ConfigurationIssuerWhiteListTest {
+
+    private static final String ISSUER_ID = "https://example.com/realms/test";
+    private static final String BASE_URL = "https://example.com";
+    private static final String SIGNING_KEY = "c2VjcmV0";
+    private static final String KID = "key-1";
+    private static final int CUSTOM_SKEW = 30;
+
+    @Test void getIssuersReturnsSingletonForMatchingIssuerId() throws Exception {
+        var testee = new ConfigurationIssuerWhiteList(ISSUER_ID, CUSTOM_SKEW, BASE_URL, SIGNING_KEY, jwksUrl(), KID);
+
+        var issuers = testee.getIssuers(ISSUER_ID);
+
+        assertThat(issuers).hasSize(1);
+        var issuer = issuers.getFirst();
+        assertThat(issuer).isInstanceOf(ConfiguredIssuer.class);
+        assertThat(issuer.getIssuerId()).isEqualTo(ISSUER_ID);
+        assertThat(issuer.getSkewSeconds()).isEqualTo(CUSTOM_SKEW);
+    }
+
+    @Test void getIssuersRejectsUnknownIssuerId() throws Exception {
+        var testee = new ConfigurationIssuerWhiteList(ISSUER_ID, CUSTOM_SKEW, BASE_URL, SIGNING_KEY, jwksUrl(), KID);
+
+        assertThatThrownBy(() -> testee.getIssuers("other-issuer"))
+                .isInstanceOf(InvalidTokenException.class)
+                .hasMessageContaining("issuer not accepted");
+    }
+
+    @Test void getIssuerReturnsConfiguredIssuerWithAllFields() throws Exception {
+        var jwks = jwksUrl();
+        var testee = new ConfigurationIssuerWhiteList(ISSUER_ID, CUSTOM_SKEW, BASE_URL, SIGNING_KEY, jwks, KID);
+
+        var issuer = (ConfiguredIssuer) testee.getIssuer(ISSUER_ID, KID);
+
+        assertThat(issuer.getIssuerId()).isEqualTo(ISSUER_ID);
+        assertThat(issuer.getSkewSeconds()).isEqualTo(CUSTOM_SKEW);
+        assertThat(issuer.getSigningKey()).isEqualTo(SIGNING_KEY);
+        assertThat(issuer.getKID()).isEqualTo(KID);
+        assertThat(issuer.getJWKURL()).isEqualTo(jwks);
+        assertThat(issuer.getBaseURL().toString()).isEqualTo(BASE_URL);
+    }
+
+    @Test void getIssuerRejectsUnknownIssuerId() throws Exception {
+        var testee = new ConfigurationIssuerWhiteList(ISSUER_ID, CUSTOM_SKEW, BASE_URL, SIGNING_KEY, jwksUrl(), KID);
+
+        assertThatThrownBy(() -> testee.getIssuer("other-issuer", KID))
+                .isInstanceOf(InvalidTokenException.class)
+                .hasMessageContaining("issuer not accepted");
+    }
+
+    @Test void getIssuerRejectsKnownIssuerWithUnknownKid() throws Exception {
+        var testee = new ConfigurationIssuerWhiteList(ISSUER_ID, CUSTOM_SKEW, BASE_URL, SIGNING_KEY, jwksUrl(), KID);
+
+        assertThatThrownBy(() -> testee.getIssuer(ISSUER_ID, "other-kid"))
+                .isInstanceOf(InvalidTokenException.class)
+                .hasMessageContaining("kid not accepted");
+    }
+
+    @Test void shortConstructorDefaultsToIssuerDefaultSkew() throws Exception {
+        var testee = new ConfigurationIssuerWhiteList(ISSUER_ID, BASE_URL, SIGNING_KEY, jwksUrl(), KID);
+
+        var issuer = testee.getIssuer(ISSUER_ID, KID);
+
+        assertThat(issuer.getSkewSeconds()).isEqualTo(Issuer.DEFAULT_MAX_SKEW_SECONDS);
+    }
+
+    @Test void constructorRejectsMalformedBaseUrl() throws Exception {
+        assertThatThrownBy(() ->
+                new ConfigurationIssuerWhiteList(ISSUER_ID, CUSTOM_SKEW, "not a url", SIGNING_KEY, jwksUrl(), KID))
+                .isInstanceOf(InvalidConfigurationPropertyValueException.class)
+                .hasMessageContaining("baseURL");
+    }
+
+    private static URL jwksUrl() throws Exception {
+        return URI.create("https://example.com/.well-known/jwks.json").toURL();
+    }
+}

--- a/src/test/java/org/ameba/oauth2/parser/HS512TokenParserTest.java
+++ b/src/test/java/org/ameba/oauth2/parser/HS512TokenParserTest.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright 2015-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.ameba.oauth2.parser;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.io.Encoders;
+import io.jsonwebtoken.security.Keys;
+import org.ameba.oauth2.InvalidTokenException;
+import org.ameba.oauth2.Issuer;
+import org.ameba.oauth2.Symmetric;
+import org.junit.jupiter.api.Test;
+
+import java.net.URL;
+import java.security.SecureRandom;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * A HS512TokenParserTest verifies the guards of the symmetric HMAC-SHA-512 token parser
+ * and pins its {@link org.ameba.oauth2.TokenParser#supportAlgorithm()} contract.
+ *
+ * @author Heiko Scherrer
+ */
+class HS512TokenParserTest {
+
+    private final HS512TokenParser testee = new HS512TokenParser();
+
+    @Test void supportAlgorithmIsHS512() {
+        assertThat(testee.supportAlgorithm()).isEqualTo("HS512");
+    }
+
+    @Test void parseRejectsNullIssuer() {
+        assertThatThrownBy(() -> testee.parse("x.y.z", null))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("symmetric issuer is null");
+    }
+
+    @Test void parseRejectsIssuerWithNullSigningKey() {
+        var issuer = new TestSymmetric(null);
+
+        assertThatThrownBy(() -> testee.parse("x.y.z", issuer))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("signing key is null or empty");
+    }
+
+    @Test void parseRejectsIssuerWithEmptySigningKey() {
+        var issuer = new TestSymmetric("");
+
+        assertThatThrownBy(() -> testee.parse("x.y.z", issuer))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("signing key is null or empty");
+    }
+
+    @Test void parseReturnsJwtForValidSignedToken() {
+        var keyBytes = randomHmacSha512KeyBytes();
+        var base64Key = Encoders.BASE64.encode(keyBytes);
+        var token = Jwts.builder()
+                .subject("test-subject")
+                .signWith(Keys.hmacShaKeyFor(keyBytes))
+                .compact();
+
+        var jwt = testee.parse(token, new TestSymmetric(base64Key));
+
+        assertThat(jwt).isNotNull();
+        var claims = (Claims) jwt.getPayload();
+        assertThat(claims.getSubject()).isEqualTo("test-subject");
+    }
+
+    @Test void parseRejectsTokenSignedWithDifferentKey() {
+        var signingKeyBytes = randomHmacSha512KeyBytes();
+        var verifyingKeyBytes = randomHmacSha512KeyBytes();
+        var token = Jwts.builder()
+                .subject("x")
+                .signWith(Keys.hmacShaKeyFor(signingKeyBytes))
+                .compact();
+        var issuer = new TestSymmetric(Encoders.BASE64.encode(verifyingKeyBytes));
+
+        assertThatThrownBy(() -> testee.parse(token, issuer))
+                .isInstanceOf(InvalidTokenException.class);
+    }
+
+    @Test void parseRejectsMalformedToken() {
+        var issuer = new TestSymmetric(Encoders.BASE64.encode(randomHmacSha512KeyBytes()));
+
+        assertThatThrownBy(() -> testee.parse("not.a.real.jwt", issuer))
+                .isInstanceOf(InvalidTokenException.class);
+    }
+
+    private static byte[] randomHmacSha512KeyBytes() {
+        var bytes = new byte[64];
+        new SecureRandom().nextBytes(bytes);
+        return bytes;
+    }
+
+    private record TestSymmetric(String signingKey) implements Symmetric {
+        @Override public String getSigningKey() { return signingKey; }
+        @Override public String getIssuerId() { return "test-issuer"; }
+        @Override public long getSkewSeconds() { return Issuer.DEFAULT_MAX_SKEW_SECONDS; }
+        @Override public URL getBaseURL() { return null; }
+    }
+}

--- a/src/test/java/org/ameba/oauth2/parser/RSA256TokenParserTest.java
+++ b/src/test/java/org/ameba/oauth2/parser/RSA256TokenParserTest.java
@@ -1,0 +1,149 @@
+/*
+ * Copyright 2015-2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.ameba.oauth2.parser;
+
+import com.auth0.jwk.Jwk;
+import com.auth0.jwk.JwkProvider;
+import com.auth0.jwk.SigningKeyNotFoundException;
+import io.jsonwebtoken.Jwts;
+import org.ameba.oauth2.Asymmetric;
+import org.ameba.oauth2.InvalidTokenException;
+import org.ameba.oauth2.Issuer;
+import org.junit.jupiter.api.Test;
+
+import java.net.URL;
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.security.NoSuchAlgorithmException;
+import java.security.PublicKey;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * A RSA256TokenParserTest verifies the guards of the asymmetric RSA SHA-256 token parser,
+ * its {@link org.ameba.oauth2.TokenParser#supportAlgorithm()} contract, and the full
+ * sign/verify round-trip through a fake {@link JwkProvider}.
+ *
+ * @author Heiko Scherrer
+ */
+class RSA256TokenParserTest {
+
+    private static final String KID = "test-kid";
+
+    @Test void supportAlgorithmIsRS256() {
+        var testee = new RSA256TokenParser();
+
+        assertThat(testee.supportAlgorithm()).isEqualTo("RS256");
+    }
+
+    @Test void parseRejectsNullIssuer() {
+        var testee = new RSA256TokenParser();
+
+        assertThatThrownBy(() -> testee.parse("x.y.z", null))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("asymmetric issuer is null");
+    }
+
+    @Test void parseRejectsIssuerWithNullKid() {
+        var testee = new RSA256TokenParser();
+        var issuer = new TestAsymmetric(null);
+
+        assertThatThrownBy(() -> testee.parse("x.y.z", issuer))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("kid is null or empty");
+    }
+
+    @Test void parseRejectsIssuerWithEmptyKid() {
+        var testee = new RSA256TokenParser();
+        var issuer = new TestAsymmetric("");
+
+        assertThatThrownBy(() -> testee.parse("x.y.z", issuer))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("kid is null or empty");
+    }
+
+    @Test void parseReturnsJwsForValidSignedToken() throws Exception {
+        var keyPair = newRsaKeyPair();
+        var token = Jwts.builder()
+                .subject("test-subject")
+                .signWith(keyPair.getPrivate(), Jwts.SIG.RS256)
+                .compact();
+        var testee = new RSA256TokenParser(jwkProviderReturning(keyPair.getPublic()));
+
+        var jws = testee.parse(token, new TestAsymmetric(KID));
+
+        assertThat(jws).isNotNull();
+        assertThat(jws.getPayload().getSubject()).isEqualTo("test-subject");
+    }
+
+    @Test void parseRejectsTokenSignedWithDifferentKeypair() throws Exception {
+        var signingKeyPair = newRsaKeyPair();
+        var verifyingKeyPair = newRsaKeyPair();
+        var token = Jwts.builder()
+                .subject("x")
+                .signWith(signingKeyPair.getPrivate(), Jwts.SIG.RS256)
+                .compact();
+        var testee = new RSA256TokenParser(jwkProviderReturning(verifyingKeyPair.getPublic()));
+
+        assertThatThrownBy(() -> testee.parse(token, new TestAsymmetric(KID)))
+                .isInstanceOf(InvalidTokenException.class);
+    }
+
+    @Test void parseRejectsMalformedToken() throws Exception {
+        var keyPair = newRsaKeyPair();
+        var testee = new RSA256TokenParser(jwkProviderReturning(keyPair.getPublic()));
+
+        assertThatThrownBy(() -> testee.parse("not.a.real.jwt", new TestAsymmetric(KID)))
+                .isInstanceOf(InvalidTokenException.class);
+    }
+
+    @Test void parseWrapsJwkProviderLookupFailures() {
+        JwkProvider failingProvider = kid -> { throw new SigningKeyNotFoundException("no key for " + kid, null); };
+        var testee = new RSA256TokenParser(failingProvider);
+
+        assertThatThrownBy(() -> testee.parse("x.y.z", new TestAsymmetric(KID)))
+                .isInstanceOf(InvalidTokenException.class)
+                .hasMessageContaining("no key");
+    }
+
+    private static KeyPair newRsaKeyPair() throws NoSuchAlgorithmException {
+        var kpg = KeyPairGenerator.getInstance("RSA");
+        kpg.initialize(2048);
+        return kpg.generateKeyPair();
+    }
+
+    private static JwkProvider jwkProviderReturning(PublicKey publicKey) {
+        var jwk = new Jwk(KID, "RSA", "RS256", null, (List<String>) null, null, null, null, null) {
+            @Override public PublicKey getPublicKey() { return publicKey; }
+        };
+        return kid -> {
+            if (!KID.equals(kid)) {
+                throw new SigningKeyNotFoundException("unknown kid " + kid, null);
+            }
+            return jwk;
+        };
+    }
+
+    private record TestAsymmetric(String kid) implements Asymmetric {
+        @Override public String getKID() { return kid; }
+        @Override public URL getJWKURL() { return null; }
+        @Override public String getIssuerId() { return "test-issuer"; }
+        @Override public long getSkewSeconds() { return Issuer.DEFAULT_MAX_SKEW_SECONDS; }
+        @Override public URL getBaseURL() { return null; }
+    }
+}


### PR DESCRIPTION
## Summary
- Add 38 tests across 6 classes that had zero coverage: `Response`, `BearerTokenExtractor`, `HS512TokenParser`, `RSA256TokenParser`, `DefaultTokenExtractor`, `ConfigurationIssuerWhiteList`.
- Fix latent bugs the tests surfaced:
  - `Response.parse()` happy path was unreachable (missing `return r;`); a second latent `ClassCastException` on the `obj` array extraction is fixed by requiring a `Class<T>` component-type token.
  - `BearerTokenExtractor.canExtract(null)` NPE → clean failure `ExtractionResult`; `stripBearer` replace-all footgun → proper prefix strip with a whitespace guard.
  - `DefaultTokenExtractor` NPEs on missing `exp` and `iss` claims → missing `exp` flows through safely (non-expiring tokens still accepted), missing `iss` throws `InvalidTokenException` (HTTP 400 via `@ResponseStatus`) instead of NPE (HTTP 500).
- Modernise to future-proof APIs: `Response.parse()` migrated from `json-path` to Jackson databind (json-path dependency removed). `HS512TokenParser` and `RSA256TokenParser` migrated from deprecated jjwt 0.12 `setSigningKey` / `parseClaimsJws` to `verifyWith` / `parseSignedClaims`.

## Test plan
- [ ] `./mvnw test` — 65/65 green expected
- [ ] Confirm the HTTP 500 → 400 posture change for malformed JWTs (missing `iss`, null `Authorization`) is the intended behavior
- [ ] Check no downstream consumer was relying on `Response.parse(String)` — the signature changed to `parse(String, Class<T>)` since the old form always threw
- [ ] Verify consumers using Base64 signing-key configs for HS512 still work end-to-end (parser preserves the implicit Base64 decode)

## Follow-up (intentionally not in this PR)
- `Issuer.DEFAULT_MAX_SKEW_SECONDS = 2592000` is treated as milliseconds in `DefaultTokenExtractor.ensureTokenNotExpired` math — effective skew is ~43 minutes, not 30 days. Likely a units bug worth a separate issue to avoid mixing a behavior change with a test-coverage PR.
- `Response.@JsonAnySetter set(name, value)` currently ignores its arguments — deserialization of unknown properties silently drops data. Out of scope here.